### PR TITLE
Fix reset handling on emulator thread

### DIFF
--- a/src/raylib/core_runner.cpp
+++ b/src/raylib/core_runner.cpp
@@ -9,7 +9,7 @@
 #include <mutex>
 #include <unistd.h>
 
-CoreRunner::CoreRunner() : running(false), paused(false), configPending(false), configResetPending(false) {}
+CoreRunner::CoreRunner() : running(false), paused(false), configPending(false), configResetPending(false), resetPending(false) {}
 CoreRunner::~CoreRunner() { Stop(); }
 
 std::string CoreRunner::CheckMandatoryRoms(const std::string& romDir) {
@@ -51,6 +51,10 @@ void CoreRunner::RequestConfigApply(const PC8801::Config& cfg, bool requireReset
     pendingConfig = cfg;
     configPending = true;
     configResetPending = requireReset;
+}
+
+void CoreRunner::RequestReset() {
+    resetPending = true;
 }
 
 void CoreRunner::UpdateInput() {
@@ -103,6 +107,10 @@ void CoreRunner::Run() {
         if (audioPaused) {
             sound.Pause(false);
             audioPaused = false;
+        }
+
+        if (resetPending.exchange(false)) {
+            pc88.Reset();
         }
 
         if (configPending) {

--- a/src/raylib/core_runner.h
+++ b/src/raylib/core_runner.h
@@ -23,6 +23,7 @@ public:
     void UpdateInput();
     void UpdateUI(bool& shouldExit);
     void DrawUI(bool& shouldExit);
+    void RequestReset();
     
     // Thread-safe config update
     void RequestConfigApply(const PC8801::Config& cfg, bool requireReset = false);
@@ -55,4 +56,5 @@ private:
     PC8801::Config pendingConfig;
     std::atomic<bool> configPending;
     std::atomic<bool> configResetPending;
+    std::atomic<bool> resetPending;
 };

--- a/src/raylib/disk_dialog.cpp
+++ b/src/raylib/disk_dialog.cpp
@@ -32,7 +32,11 @@ UIManager::~UIManager() {
 void UIManager::Init() {}
 
 void UIManager::Update(bool& shouldExit, PC88* pc88, CoreRunner* coreRunner) {
-    if (IsKeyPressed(KEY_F12)) ToggleMenu(coreRunner);
+    if (IsKeyPressed(KEY_F10)) ToggleMenu(coreRunner);
+    if (IsKeyPressed(KEY_F12)) {
+        if (coreRunner) coreRunner->RequestReset();
+        else pc88->Reset();
+    }
     if (IsMouseButtonPressed(MOUSE_RIGHT_BUTTON) && !showMenu) {
         if (GetMouseY() < GetScreenHeight() - 24) ToggleMenu(coreRunner);
     }
@@ -138,7 +142,11 @@ void UIManager::DrawMainMenu(DiskManager* diskmgr, PC88* pc88, bool& shouldExit,
     }
 
     btnY += 35; // Space after group box
-    if (GuiButton({ x + 10, btnY, width - 20, btnH }, "Reset PC-8801")) { pc88->Reset(); ToggleMenu(coreRunner); }
+    if (GuiButton({ x + 10, btnY, width - 20, btnH }, "Reset PC-8801")) {
+        if (coreRunner) coreRunner->RequestReset();
+        else pc88->Reset();
+        ToggleMenu(coreRunner);
+    }
     btnY += 34;
     if (GuiButton({ x + 10, btnY, width - 20, btnH }, "Settings")) showSettings = true;
     btnY += 34;


### PR DESCRIPTION
## Summary
- Route UI reset actions through CoreRunner instead of calling PC88::Reset directly from the UI thread
- Process pending resets at the start of the emulator thread loop
- Restore F10 as the menu shortcut and F12 as reset to match README behavior

## Verification
- cmake -S . -B build
- cmake --build build -j8