### PR TITLE
Fix Sound Board II audio path and OPNA levels

### DIFF
--- a/src/devices/opna.cpp
+++ b/src/devices/opna.cpp
@@ -1291,18 +1291,19 @@ bool OPNA::LoadRhythmSample(const char* path)
 		uint32 fsize;
 		char buf[MAX_PATH] = "";
 		if (path)
-			strncpy(buf, path, MAX_PATH);
-		strncat(buf, "2608_", MAX_PATH);
-		strncat(buf, rhythmname[i], MAX_PATH);
-		strncat(buf, ".WAV", MAX_PATH);
+			strncpy(buf, path, MAX_PATH - 1);
+		strncat(buf, "2608_", MAX_PATH - strlen(buf) - 1);
+		strncat(buf, rhythmname[i], MAX_PATH - strlen(buf) - 1);
+		strncat(buf, ".WAV", MAX_PATH - strlen(buf) - 1);
 
 		if (!file.Open(buf, FileIO::readonly))
 		{
 			if (i != 5)
 				break;
+			buf[0] = '\0';
 			if (path)
-				strncpy(buf, path, MAX_PATH);
-			strncpy(buf, "2608_RYM.WAV", MAX_PATH);
+				strncpy(buf, path, MAX_PATH - 1);
+			strncat(buf, "2608_RYM.WAV", MAX_PATH - strlen(buf) - 1);
 			if (!file.Open(buf, FileIO::readonly))
 				break;
 		}
@@ -1334,9 +1335,9 @@ bool OPNA::LoadRhythmSample(const char* path)
 		fsize /= 2;
 		if (fsize >= 0x100000 || whdr.tag != 1 || whdr.nch != 1)
 			break;
-		fsize = Max(fsize, (1<<31)/1024);
+		fsize = Min(fsize, (1<<31)/1024);
 		
-		delete rhythm[i].sample;
+		delete[] rhythm[i].sample;
 		rhythm[i].sample = new int16[fsize];
 		if (!rhythm[i].sample)
 			break;

--- a/src/devices/opna.cpp
+++ b/src/devices/opna.cpp
@@ -627,6 +627,11 @@ void OPNABase::SetADPCMBReg(uint addr, uint data)
 	switch (addr)
 	{
 	case 0x00:		// Control Register 1
+		if (((data & 0x60) == 0x20 || (data & 0x60) == 0x60) &&
+			((control1 & 0x60) != (data & 0x60)))
+		{
+			memaddr = startaddr;
+		}
 		if ((data & 0x80) && !adpcmplay)
 		{
 			adpcmplay = true;

--- a/src/pc88/opnif.cpp
+++ b/src/pc88/opnif.cpp
@@ -171,10 +171,7 @@ void IFCALL OPNIF::Mix(int32* dest, int nsamples)
 //
 static inline int ConvertVolume(int volume)
 {
-	if (volume <= 0) return -200;
-	// Map 128 to 0dB, and 0-127 to negative dB values.
-	// Simple linear scale for now: 128=0dB, 64=-32dB, 1=-63dB.
-	return (volume - 128) / 2;
+	return Limit(volume, 40, -100);
 }
 
 void OPNIF::SetVolume(const Config* config)

--- a/src/pc88/pc88.cpp
+++ b/src/pc88/pc88.cpp
@@ -48,6 +48,8 @@ PC88::PC88()
 {
 	assert((1 << MemoryManager::pagebits) <= 0x400); 
 	clock = 100;
+	cfgflags = 0;
+	cfgflag2 = 0;
 	DIAGINIT(&cpu1);
 	dexc = 0;
 }
@@ -532,7 +534,7 @@ bool PC88::ConnectDevices(const char* romDir)
 		{ 0, 0, 0 }
 	};
 	opn2 = new PC8801::OPNIF(DEV_ID('O', 'P', 'N', '2'));
-	if (!opn2->Init(&bus1, pint4, popnio, this, romDir)) return false;
+	if (!opn2->Init(&bus1, pint4, popnio2, this, romDir)) return false;
 	if (!opn2 || !bus1.Connect(opn2, c_opn2)) return false;
 	opn2->SetIMask(0xaa, 0x80);
 	

--- a/src/raylib/audio_out.cpp
+++ b/src/raylib/audio_out.cpp
@@ -1,36 +1,16 @@
 #include "audio_out.h"
 #include "pc88/config.h"
 #include <algorithm>
-#include <iostream>
-#include <cstdio>
 
 static RaylibSound* s_current_sound = nullptr;
 
 static void GlobalAudioCallback(void* buffer, unsigned int frames) {
     if (s_current_sound) {
-        short* out = (short*)buffer;
-        static std::vector<int32_t> mixBuf;
-        mixBuf.assign(frames * 2, 0);
-        s_current_sound->MixInternal(mixBuf.data(), frames);
-
-        long long sum = 0;
-        for (unsigned int i = 0; i < frames * 2; i++) {
-            int32_t s = mixBuf[i];
-            if (s > 32767) s = 32767;
-            if (s < -32768) s = -32768;
-            out[i] = (short)s;
-            sum += (s < 0 ? -s : s);
-        }
-        
-        static int audioCounter = 0;
-        if (audioCounter++ % 100 == 0 && sum > 0) {
-            fprintf(stderr, "[VERIFY] Audio is ACTIVE (avg amplitude: %lld)\n", sum / (frames * 2));
-            fflush(stderr);
-        }
+        s_current_sound->FillOutput((int16_t*)buffer, frames);
     }
 }
 
-RaylibSound::RaylibSound() : sampleRate(44100) { stream = {0}; }
+RaylibSound::RaylibSound() : outputSource(nullptr), sampleRate(44100) { stream = {0}; }
 RaylibSound::~RaylibSound() { Cleanup(); }
 
 void RaylibSound::Init() {
@@ -46,27 +26,21 @@ void RaylibSound::Cleanup() {
     if (s_current_sound == this) s_current_sound = nullptr;
 }
 
-bool IFCALL RaylibSound::Connect(ISoundSource* src) {
+void RaylibSound::SetSource(SoundSource* src) {
     std::lock_guard<std::recursive_mutex> lock(mutex);
-    for (auto* s : sources) if (s == src) return true;
-    sources.push_back(src);
-    src->SetRate(sampleRate);
-    return true;
+    outputSource = src;
 }
 
-bool IFCALL RaylibSound::Disconnect(ISoundSource* src) {
+void RaylibSound::FillOutput(int16_t* buffer, unsigned int frames) {
     std::lock_guard<std::recursive_mutex> lock(mutex);
-    auto it = std::find(sources.begin(), sources.end(), src);
-    if (it != sources.end()) { sources.erase(it); return true; }
-    return false;
-}
-
-bool IFCALL RaylibSound::Update(ISoundSource* src) { return true; }
-int IFCALL RaylibSound::GetSubsampleTime(ISoundSource* src) { return 0; }
-
-void RaylibSound::MixInternal(int32_t* buffer, unsigned int frames) {
-    std::lock_guard<std::recursive_mutex> lock(mutex);
-    for (auto* src : sources) src->Mix(buffer, frames);
+    if (outputSource) {
+        int got = outputSource->Get(buffer, frames);
+        if (got < (int)frames) {
+            std::fill(buffer + got * 2, buffer + frames * 2, 0);
+        }
+    } else {
+        std::fill(buffer, buffer + frames * 2, 0);
+    }
 }
 
 void RaylibSound::Start() {

--- a/src/raylib/audio_out.h
+++ b/src/raylib/audio_out.h
@@ -1,38 +1,31 @@
 #pragma once
 
-#include "ifcommon.h"
 #include "raylib.h"
-#include <vector>
+#include "soundsrc.h"
 #include <mutex>
 #include <cstdint>
 
 namespace PC8801 { class Config; }
 
-class RaylibSound : public ISoundControl {
+class RaylibSound {
 public:
     RaylibSound();
     virtual ~RaylibSound();
-
-    // ISoundControl implementation
-    bool IFCALL Connect(ISoundSource* src) override;
-    bool IFCALL Disconnect(ISoundSource* src) override;
-    
-    bool IFCALL Update(ISoundSource* src) override;
-    int  IFCALL GetSubsampleTime(ISoundSource* src) override;
 
     void Init();
     void Start();
     void Pause(bool paused);
     void SetVolume(const PC8801::Config* cfg);
     void Cleanup();
+    void SetSource(SoundSource* src);
 
-    void MixInternal(int32_t* buffer, unsigned int frames);
+    void FillOutput(int16_t* buffer, unsigned int frames);
 
 private:
     static void AudioCallback(void* buffer, unsigned int frames);
 
     AudioStream stream;
-    std::vector<ISoundSource*> sources;
+    SoundSource* outputSource;
     std::recursive_mutex mutex;
     int sampleRate;
 };

--- a/src/raylib/config.cpp
+++ b/src/raylib/config.cpp
@@ -8,16 +8,21 @@ namespace Config {
 
 static PC8801::Config g_config;
 
+static int NormalizeVolume(int volume) {
+    return volume > 40 ? 0 : volume;
+}
+
 static void NormalizeLoadedConfig(PC8801::Config& cfg) {
-    if (cfg.volrhythm > 0 && cfg.volbd > 0 &&
-        cfg.volsd == 0 && cfg.voltop == 0 && cfg.volhh == 0 &&
-        cfg.voltom == 0 && cfg.volrim == 0) {
-        cfg.volsd = cfg.volbd;
-        cfg.voltop = cfg.volbd;
-        cfg.volhh = cfg.volbd;
-        cfg.voltom = cfg.volbd;
-        cfg.volrim = cfg.volbd;
-    }
+    cfg.volfm = NormalizeVolume(cfg.volfm);
+    cfg.volssg = NormalizeVolume(cfg.volssg);
+    cfg.voladpcm = NormalizeVolume(cfg.voladpcm);
+    cfg.volrhythm = NormalizeVolume(cfg.volrhythm);
+    cfg.volbd = NormalizeVolume(cfg.volbd);
+    cfg.volsd = NormalizeVolume(cfg.volsd);
+    cfg.voltop = NormalizeVolume(cfg.voltop);
+    cfg.volhh = NormalizeVolume(cfg.volhh);
+    cfg.voltom = NormalizeVolume(cfg.voltom);
+    cfg.volrim = NormalizeVolume(cfg.volrim);
 }
 
 static std::string GetConfigFilePath() {
@@ -44,9 +49,9 @@ void Load(PC8801::Config& cfg) {
                 PC8801::Config::precisemixing |
                 PC8801::Config::mixsoundalways;
     cfg.flag2 = PC8801::Config::usefmclock;
-    cfg.volfm = 64; cfg.volssg = 64; cfg.voladpcm = 64; cfg.volrhythm = 64;
-    cfg.volbd = 64; cfg.volsd = 64; cfg.voltop = 64;
-    cfg.volhh = 64; cfg.voltom = 64; cfg.volrim = 64;
+    cfg.volfm = 0; cfg.volssg = 0; cfg.voladpcm = 0; cfg.volrhythm = 0;
+    cfg.volbd = 0; cfg.volsd = 0; cfg.voltop = 0;
+    cfg.volhh = 0; cfg.voltom = 0; cfg.volrim = 0;
     cfg.mastervol = 128; // 100%
     cfg.soundbuffer = 4096;
 

--- a/src/raylib/config.cpp
+++ b/src/raylib/config.cpp
@@ -8,6 +8,18 @@ namespace Config {
 
 static PC8801::Config g_config;
 
+static void NormalizeLoadedConfig(PC8801::Config& cfg) {
+    if (cfg.volrhythm > 0 && cfg.volbd > 0 &&
+        cfg.volsd == 0 && cfg.voltop == 0 && cfg.volhh == 0 &&
+        cfg.voltom == 0 && cfg.volrim == 0) {
+        cfg.volsd = cfg.volbd;
+        cfg.voltop = cfg.volbd;
+        cfg.volhh = cfg.volbd;
+        cfg.voltom = cfg.volbd;
+        cfg.volrim = cfg.volbd;
+    }
+}
+
 static std::string GetConfigFilePath() {
     std::string dir = Paths::GetConfigDir();
     struct stat st;
@@ -32,8 +44,11 @@ void Load(PC8801::Config& cfg) {
                 PC8801::Config::precisemixing |
                 PC8801::Config::mixsoundalways;
     cfg.flag2 = PC8801::Config::usefmclock;
-    cfg.volfm = 64; cfg.volssg = 64; cfg.voladpcm = 64; cfg.volrhythm = 64; cfg.volbd = 64;
+    cfg.volfm = 64; cfg.volssg = 64; cfg.voladpcm = 64; cfg.volrhythm = 64;
+    cfg.volbd = 64; cfg.volsd = 64; cfg.voltop = 64;
+    cfg.volhh = 64; cfg.voltom = 64; cfg.volrim = 64;
     cfg.mastervol = 128; // 100%
+    cfg.soundbuffer = 4096;
 
     // Try to load from file
     std::string path = GetConfigFilePath();
@@ -43,6 +58,7 @@ void Load(PC8801::Config& cfg) {
         file.Close();
         // Recalculate mainsubratio in case it was saved inconsistently
         cfg.mainsubratio = (cfg.clock >= 6) ? 2 : 1;
+        NormalizeLoadedConfig(cfg);
     } else {
         // Save defaults if file doesn't exist
         Save(cfg);

--- a/src/raylib/core_runner.cpp
+++ b/src/raylib/core_runner.cpp
@@ -36,11 +36,16 @@ bool CoreRunner::Init(Draw* draw) {
     
     pc88.ApplyConfig(&Config::Get());
     pc88.Reset();
+    uint soundBuffer = Config::Get().soundbuffer;
+    if (soundBuffer < 1024) soundBuffer = 4096;
+    if (!coreSound.Init(&pc88, 44100, soundBuffer)) return false;
+    coreSound.ApplyConfig(&Config::Get());
     sound.Init();
     sound.SetVolume(&Config::Get());
-    sound.Connect(pc88.GetOPN1());
-    sound.Connect(pc88.GetOPN2());
-    sound.Connect(pc88.GetBEEP());
+    sound.SetSource(coreSound.GetSoundSource());
+    pc88.GetOPN1()->Connect(&coreSound);
+    pc88.GetOPN2()->Connect(&coreSound);
+    pc88.GetBEEP()->Connect(&coreSound);
     keyInput.Init(&pc88);
     uiManager.Init();
     return true;
@@ -108,6 +113,7 @@ void CoreRunner::Run() {
         if (configPending) {
             std::lock_guard<std::mutex> lock(configMutex);
             pc88.ApplyConfig(&pendingConfig);
+            coreSound.ApplyConfig(&pendingConfig);
             sound.SetVolume(&pendingConfig);
             if (configResetPending) {
                 pc88.Reset(); 

--- a/src/raylib/core_runner.h
+++ b/src/raylib/core_runner.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "pc88.h"
+#include "sound.h"
 #include "diskmgr.h"
 #include "tapemgr.h"
 #include "audio_out.h"
@@ -41,6 +42,7 @@ private:
     PC88 pc88;
     DiskManager diskmgr;
     TapeManager tapemgr;
+    PC8801::Sound coreSound;
     RaylibSound sound;
     KeyInput keyInput;
     UIManager uiManager;

--- a/src/raylib/disk_dialog.cpp
+++ b/src/raylib/disk_dialog.cpp
@@ -275,6 +275,8 @@ void UIManager::DrawSettings(PC8801::Config& cfg, PC88* pc88, CoreRunner* coreRu
         pY += 10;
         if (GuiButton({ x + 100, pY + 10, 150, 24 }, "Reset to Defaults")) {
             cfg.volfm = 64; cfg.volssg = 64; cfg.voladpcm = 64; cfg.volrhythm = 64;
+            cfg.volbd = 64; cfg.volsd = 64; cfg.voltop = 64;
+            cfg.volhh = 64; cfg.voltom = 64; cfg.volrim = 64;
             changed = true;
         }
 

--- a/src/raylib/disk_dialog.cpp
+++ b/src/raylib/disk_dialog.cpp
@@ -267,16 +267,16 @@ void UIManager::DrawSettings(PC8801::Config& cfg, PC88* pc88, CoreRunner* coreRu
         for (int i = 0; i < 4; i++) {
             GuiLabel({ x + 25, pY + 10, 80, 20 }, names[i]);
             float val = (float)*vPtrs[i];
-            GuiSliderBar({ x + 100, pY + 10, 240, 16 }, "0", "128", &val, 0, 128);
+            GuiSliderBar({ x + 100, pY + 10, 240, 16 }, "-100dB", "+40dB", &val, -100, 40);
             if ((int)val != *vPtrs[i]) { *vPtrs[i] = (int)val; changed = true; }
             pY += 28;
         }
 
         pY += 10;
         if (GuiButton({ x + 100, pY + 10, 150, 24 }, "Reset to Defaults")) {
-            cfg.volfm = 64; cfg.volssg = 64; cfg.voladpcm = 64; cfg.volrhythm = 64;
-            cfg.volbd = 64; cfg.volsd = 64; cfg.voltop = 64;
-            cfg.volhh = 64; cfg.voltom = 64; cfg.volrim = 64;
+            cfg.volfm = 0; cfg.volssg = 0; cfg.voladpcm = 0; cfg.volrhythm = 0;
+            cfg.volbd = 0; cfg.volsd = 0; cfg.voltop = 0;
+            cfg.volhh = 0; cfg.voltom = 0; cfg.volrim = 0;
             changed = true;
         }
 


### PR DESCRIPTION
## Summary
- route raylib audio output through the original PC8801::Sound buffering path instead of mixing OPNA/BEEP directly
- fix Sound Board II A8h auxiliary I/O port wiring and initialize PC88 config flags
- restore OPNA volume settings to the original dB contract and migrate old raylib 0-128 saved values
- reset ADPCM RAM read/write position when entering ADPCM RAM access mode and fix rhythm sample loading issues

## Verification
- cmake --build build --target m88_raylib