### PR TITLE
ci: fix Windows build by letting CMake auto-detect VS generator

### DIFF
--- a/scripts/build_win.ps1
+++ b/scripts/build_win.ps1
@@ -3,7 +3,7 @@ param (
 )
 
 # M88M Windows Build Script (PowerShell)
-# Requirement: Visual Studio 2022 and CMake
+# Requirement: Visual Studio 2022 or later, and CMake
 
 $BuildDir = "build"
 $Config = "RelWithDebInfo"
@@ -21,7 +21,10 @@ if (-not (Test-Path $BuildDir)) {
 }
 
 Write-Host "Configuring project..."
-cmake -S . -B $BuildDir -G "Visual Studio 17 2022" -A x64
+# Let CMake auto-detect the installed Visual Studio generator (VS 2022 / VS 2026 / etc.).
+# GitHub's windows-2025 runner now ships VS 2026, so a hardcoded "Visual Studio 17 2022"
+# generator fails with "could not find any instance of Visual Studio".
+cmake -S . -B $BuildDir -A x64
 if ($LASTEXITCODE -ne 0) {
     Write-Error "Configuration failed."
     exit $LASTEXITCODE


### PR DESCRIPTION
## Summary

`runs-on: windows-2025` ランナーが今日（2026-06-11）から実際には `windows-2025-vs2026`（Visual Studio 2026）イメージを割り当てるようになり、`scripts/build_win.ps1` がハードコードしていた `-G "Visual Studio 17 2022"` ジェネレータが「could not find any instance of Visual Studio」で失敗していました。

ジェネレータのハードコードを外し、CMakeにインストール済みのVisual Studioを自動検出させるよう変更します。これによりVS2022イメージ・VS2026イメージ・ローカル環境のいずれでもビルドできます。

失敗ログのRunner Imageに `Image: windows-2025-vs2026` と明記されており、5/17の実行は成功・本日が初失敗（スクリプトは無変更）であることから、環境側の変更が原因と確定しています。

## Test plan

- [x] 失敗ログでランナーが `windows-2025-vs2026`（VS2026）イメージだったことを確認
- [x] 5/17成功・6/11初失敗・スクリプト無変更から環境起因と特定
- [ ] このPRのCI（Build Windows）が通過することを確認