### PR TITLE
fix: ⌘Q 終了確認で No を選ぶと設定メニューが開く問題を修正

### DIFF
--- a/src/raylib/disk_dialog.cpp
+++ b/src/raylib/disk_dialog.cpp
@@ -67,7 +67,7 @@ static std::string GetDirFromPath(const std::string& path) {
 }
 
 UIManager::UIManager() :
-    showMenu(false), modalState(MODAL_NONE), showSettings(false), showStateDialog(false), showRecentDialog(false),
+    showMenu(false), modalState(MODAL_NONE), quitOpenedMenu(false), showSettings(false), showStateDialog(false), showRecentDialog(false),
     selectingDiskForDrive(-1), recentDiskTargetDrive(-1), activeTab(0),
     currentStateSlot(0),
     diskScrollOffset({ 0, 0 }),
@@ -163,7 +163,7 @@ void UIManager::Update(bool& shouldExit, PC88* pc88, CoreRunner* coreRunner) {
         if (GetMouseY() < GetScreenHeight() - 24) ToggleMenu(coreRunner);
     }
     if (showMenu && IsKeyPressed(KEY_ESCAPE)) {
-        if (modalState != MODAL_NONE) modalState = MODAL_NONE;
+        if (modalState != MODAL_NONE) DismissConfirm();
         else if (selectingDiskForDrive != -1) selectingDiskForDrive = -1;
         else if (showRecentDialog) showRecentDialog = false;
         else if (showStateDialog) showStateDialog = false;
@@ -1333,7 +1333,7 @@ void UIManager::DrawConfirmDialog(bool& shouldExit, PC88* pc88, CoreRunner* core
     const char* msg = (modalState == MODAL_CONFIRM_RESET) ? "Are you sure you want to reset?" : "Are you sure you want to quit?";
 
     if (GuiWindowBox({ x, y, width, height }, title)) {
-        modalState = MODAL_NONE;
+        DismissConfirm();
     }
 
     GuiLabel({ x + 20, y + 40, width - 40, 20 }, msg);
@@ -1343,13 +1343,23 @@ void UIManager::DrawConfirmDialog(bool& shouldExit, PC88* pc88, CoreRunner* core
             if (coreRunner) coreRunner->RequestReset();
             else pc88->Reset();
             ToggleMenu(coreRunner);
+            modalState = MODAL_NONE;
         } else if (modalState == MODAL_CONFIRM_QUIT) {
             shouldExit = true;
+            modalState = MODAL_NONE;
         }
-        modalState = MODAL_NONE;
     }
 
     if (GuiButton({ x + 160, y + 90, 100, 30 }, "No")) {
-        modalState = MODAL_NONE;
+        DismissConfirm();
     }
+}
+
+// 確認ダイアログを閉じる。⌘Q 等でメニューが閉じた状態から開かれた
+// Quit 確認の場合は、メニューも一緒に畳んで設定画面が残らないようにする。
+void UIManager::DismissConfirm() {
+    bool closeMenu = (modalState == MODAL_CONFIRM_QUIT) && quitOpenedMenu;
+    modalState = MODAL_NONE;
+    quitOpenedMenu = false;
+    if (closeMenu) showMenu = false;
 }

--- a/src/raylib/disk_dialog.h
+++ b/src/raylib/disk_dialog.h
@@ -25,7 +25,13 @@ public:
 
     bool IsMenuOpen() const { return showMenu; }
     void ToggleMenu(class CoreRunner* coreRunner = nullptr);
-    void RequestQuitConfirm() { modalState = MODAL_CONFIRM_QUIT; showMenu = true; }
+    void RequestQuitConfirm() {
+        // メニューが閉じている状態(⌘Q 等)から呼ばれた場合は、
+        // 確認ダイアログを閉じたときにメニューも畳む必要がある
+        if (!showMenu) quitOpenedMenu = true;
+        modalState = MODAL_CONFIRM_QUIT;
+        showMenu = true;
+    }
 
     enum ModalState {
         MODAL_NONE,
@@ -40,6 +46,7 @@ private:
     void DrawRecentDiskDialog(DiskManager* diskmgr);
     void DrawStateDialog(DiskManager* diskmgr, class CoreRunner* coreRunner);
     void DrawConfirmDialog(bool& shouldExit, class PC88* pc88, class CoreRunner* coreRunner);
+    void DismissConfirm();
     void DrawStatusBar(DiskManager* diskmgr);
     void DrawDriveStatus(DiskManager* diskmgr, int drive, float x, float y);
     std::string GetStatePath(DiskManager* diskmgr, int slot) const;
@@ -51,6 +58,7 @@ private:
 
     bool showMenu;
     ModalState modalState;
+    bool quitOpenedMenu; // RequestQuitConfirm がメニューを開いたか
     bool showSettings;
     bool showStateDialog;
     bool showRecentDialog;


### PR DESCRIPTION
Quit/Reset 確認が DrawConfirmDialog を共用しており、RequestQuitConfirm がメニューを閉じた状態でも showMenu を true に強制するため、No 選択後に
showMenu が残ってメインメニューが開いていた。

quitOpenedMenu フラグで「確認ダイアログが自分でメニューを開いたか」を
記録し、閉じる処理を DismissConfirm() に集約。⌘Q 由来の Quit 確認を
閉じたときだけメニューも畳むようにした。閉じる経路(No/×/ESC)を統一。