### PR TITLE
Fix vertical clipping of ROM error dialog text

### DIFF
--- a/src/raylib/app.cpp
+++ b/src/raylib/app.cpp
@@ -284,7 +284,7 @@ int main() {
                 Color textColor = GetColor(GuiGetStyle(DEFAULT, TEXT_COLOR_NORMAL));
                 while (std::getline(ss, line, '\n')) {
                     if (IsFontValid(fontEn)) {
-                        DrawTextEx(fontEn, line.c_str(), { x + 25, (float)lineY }, 14, 1, textColor);
+                        DrawTextEx(fontEn, line.c_str(), { x + 25, (float)lineY }, 16, 1, textColor);
                     } else {
                         DrawText(line.c_str(), (int)x + 25, lineY, 10, textColor);
                     }


### PR DESCRIPTION
## Summary

ROM が見つからないときに表示される「BIOS ROM Error」ダイアログのテキストが、上下で切れて表示される問題を修正しました。

- `src/raylib/app.cpp` のダイアログ描画部分だけ、EN フォント `fontEn` を 14px で描画していました。
- このフォントは base size 16px で読み込まれ、`TEXTURE_FILTER_POINT`（ニアレストネイバー）が設定されています。16→14 という非整数倍の縮小によりピクセル行が間引かれ、ビットマップ的なフォント（ChicagoKare）の文字の上下が欠けて見えていました。
- 他の描画箇所（`disk_dialog.cpp` など）と同様にネイティブの 16px で描画するよう変更し、1:1 で鮮明にレンダリングされるようにしました。

## Test plan

- [x] macOS でビルドが成功することを確認
- [x] roms ディレクトリが空の状態でアプリを起動し、エラーダイアログを表示
- [x] テキストが上下で切れず鮮明に表示されることをスクリーンショットで確認
- [x] 最長行のパスがダイアログ幅（500px）内に収まることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012tVgd8rZEE5oUAzGqJLcSm