### PR TITLE
Restore execute bit on Haiku release binaries

### DIFF
--- a/.github/workflows/build-haiku.yml
+++ b/.github/workflows/build-haiku.yml
@@ -85,3 +85,5 @@ jobs:
     with:
       zip-artifacts: |
         m88m-haiku-x64-app=m88m-{version}-haiku-x64.zip
+      executable-paths: |
+        m88m

--- a/.github/workflows/publish-release-assets.yml
+++ b/.github/workflows/publish-release-assets.yml
@@ -13,6 +13,14 @@ on:
         required: false
         default: ""
         type: string
+      executable-paths:
+        description: |
+          Newline-separated filename globs inside zipped artifacts that must keep the
+          execute bit. actions/upload-artifact drops file modes, so the bit has to be
+          restored here before the archive is created.
+        required: false
+        default: ""
+        type: string
 
 permissions:
   contents: read
@@ -44,6 +52,7 @@ jobs:
         RELEASE_TAG: ${{ github.event.release.tag_name }}
         ASSET_PATTERNS: ${{ inputs.asset-patterns }}
         ZIP_ARTIFACTS: ${{ inputs.zip-artifacts }}
+        EXECUTABLE_PATHS: ${{ inputs.executable-paths }}
         VERSION: ${{ steps.ver.outputs.version }}
       run: |
         if [ -z "$RELEASE_TAG" ]; then
@@ -83,6 +92,11 @@ jobs:
               exit 1
             fi
           fi
+
+          while IFS= read -r exec_pattern; do
+            [ -z "$exec_pattern" ] && continue
+            find "$artifact_dir" -type f -name "$exec_pattern" -exec chmod +x {} +
+          done <<< "$EXECUTABLE_PATHS"
 
           output_zip="$(pwd)/release-upload/$zip_name"
           (cd "$artifact_dir" && zip -r "$output_zip" .)

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Prebuilt binaries are available on the [**Releases**](https://github.com/bubio/M
 >
 > **Windows on ARM:** the OS ships no desktop OpenGL driver, which M88M (via raylib) requires. If M88M launches but no window appears, install the **"OpenCL, OpenGL, and Vulkan Compatibility Pack"** from the Microsoft Store and start it again.
 >
-> **Haiku:** the `.zip` contains the `m88m` executable and license files only. SDL2 must be installed on the system before running it, for example with `pkgman install libsdl2`.
+> **Haiku:** the `.zip` contains the `m88m` executable and license files only. SDL2 must be installed on the system before running it, for example with `pkgman install libsdl2`. If the extracted `m88m` fails to launch with "Invalid Argument", it lost its execute permission during extraction — restore it with `chmod +x m88m`.
 
 ## Prerequisites
 


### PR DESCRIPTION
## Summary

Haiku 版のリリース zip に含まれる `m88m` に実行権限が付いておらず、展開してもアプリが起動せず「Invalid Argument」ダイアログが出る問題を修正します。

原因は `actions/upload-artifact` がファイルモードを保持しないことです。Haiku VM 内では 0755 でステージされた `m88m` が、publish ジョブでダウンロードされた時点で 0644 になり、そのまま zip に固められていました。Haiku は実行権限のないファイルの起動を `B_BAD_VALUE`（Invalid Argument）で拒否します。ビルドアーティファクトを ISO 化したものが動いていたのは、ISO9660 がパーミッション情報を持たず Haiku が読み込み時に `r-x` を合成するためで、バイナリ自体に問題はありませんでした。

変更内容:

- `publish-release-assets.yml` に `executable-paths` 入力を追加し、zip 作成の直前に該当ファイルへ `chmod +x` を適用（`artifact_dir` のフォールバック解決後に実行）。未指定時は無効なので Windows 側の挙動は変わりません
- `build-haiku.yml` から `m88m` を指定
- README の Haiku 注記に、症状と `chmod +x m88m` による復旧方法を追記

公開済みの v1.2.1 / v1.2.0-refresh のアセットは、実行権限を付け直した zip に差し替え済みです（バイナリの内容は元と同一）。

## Test plan

- [x] リリース zip の中身を `unzip -Z` で確認し、`m88m` が `-rw-r--r--` であることを特定
- [x] Haiku 実機（UTM）で `chmod +x m88m` 後に起動することを確認
- [x] publish ジョブの chmod → zip の流れをローカルで再現し、`m88m` のみ `-rwxr-xr-x`、他のファイルは 0644 のままになることを確認
- [x] `executable-paths` が空の場合（Windows）に空行が `continue` され、パターン不一致でも `find -exec` がステップを失敗させないことを確認
- [x] 差し替え後の zip を GitHub から再ダウンロードし、`-rwxr-xr-x` と元バイナリとのバイト一致（`cmp`）を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SBVwYpZVQqium9r63ppKQ2