### PR TITLE
Fix menu opening disk selector after drop mount

### DIFF
--- a/src/raylib/app.cpp
+++ b/src/raylib/app.cpp
@@ -322,7 +322,7 @@ int main() {
 #ifdef __HAIKU__
         std::string haikuDroppedPath;
         while (HaikuPollDroppedFile(haikuDroppedPath)) {
-            core.GetUIManager()->MountDisk(core.GetDiskManager(), haikuDroppedPath.c_str(), 0, 1);
+            core.GetUIManager()->MountDisk(core.GetDiskManager(), haikuDroppedPath.c_str(), 0, 1, false);
             if (Config::Get().flag2 & PC8801::Config::resetondrop) {
                 core.RequestReset();
             }
@@ -332,7 +332,7 @@ int main() {
         if (IsFileDropped()) {
             FilePathList droppedFiles = LoadDroppedFiles();
             if (droppedFiles.count > 0) {
-                core.GetUIManager()->MountDisk(core.GetDiskManager(), droppedFiles.paths[0], 0, 1);
+                core.GetUIManager()->MountDisk(core.GetDiskManager(), droppedFiles.paths[0], 0, 1, false);
                 if (Config::Get().flag2 & PC8801::Config::resetondrop) {
                     core.RequestReset();
                 }

--- a/src/raylib/disk_dialog.cpp
+++ b/src/raylib/disk_dialog.cpp
@@ -1375,7 +1375,7 @@ void UIManager::DrawStatusBar(DiskManager* diskmgr) {
     DrawEnText(TextFormat("%d FPS", GetFPS()), (int)sW - 80, (int)textY, statusText);
 }
 
-void UIManager::MountDisk(DiskManager* diskmgr, const char* path, int img1, int img2) {
+void UIManager::MountDisk(DiskManager* diskmgr, const char* path, int img1, int img2, bool openSelectorIfNeeded) {
     std::string mountPath = NormalizeSelectedPath(path);
     if (mountPath.empty()) return;
 
@@ -1434,7 +1434,10 @@ void UIManager::MountDisk(DiskManager* diskmgr, const char* path, int img1, int 
 #endif
         AddRecent(mountPath);
         // If mounting to only one drive, show selector if multiple images exist
-        if (origImg1 >= 0 && origImg2 < 0) {
+        if (!openSelectorIfNeeded) {
+            selectingDiskForDrive = -1;
+            selectingBothDrives = false;
+        } else if (origImg1 >= 0 && origImg2 < 0) {
             if (availableImages > 1) selectingDiskForDrive = 0;
             else selectingDiskForDrive = -1;
             selectingBothDrives = false;

--- a/src/raylib/disk_dialog.h
+++ b/src/raylib/disk_dialog.h
@@ -16,7 +16,7 @@ public:
     void Draw(DiskManager* diskmgr, PC8801::Config& cfg, class PC88* pc88, class CoreRunner* coreRunner, bool& shouldExit);
     void OpenNativeDialog(DiskManager* diskmgr, int drive);
     void OpenBothDrives(DiskManager* diskmgr);
-    void MountDisk(DiskManager* diskmgr, const char* path, int img1, int img2);
+    void MountDisk(DiskManager* diskmgr, const char* path, int img1, int img2, bool openSelectorIfNeeded = true);
     void AddRecent(const std::string& path);
     void LoadRecent();
     void SaveRecent();


### PR DESCRIPTION
## Summary
- m3uファイルなどをドロップしてマルチディスクをドライブへマウントした後、メニューを開くとメインメニューではなくディスク選択画面が表示されてしまう不具合を修正
- `MountDisk` に `openSelectorIfNeeded` 引数を追加し、ドロップ経由の呼び出し（Haiku/通常両方）では選択状態を残さないようにした
- メニューから明示的にディスクを開いた場合（`OpenBothDrives` 等）は従来通り選択画面が表示される

## Test plan
- [x] ローカルでビルドが通ることを確認 (`make -j4`)