### PR TITLE
Add Clear button to Recent Disks dialog

### DIFF
--- a/src/raylib/disk_dialog.cpp
+++ b/src/raylib/disk_dialog.cpp
@@ -1582,6 +1582,9 @@ void UIManager::DrawRecentDiskDialog(DiskManager* diskmgr) {
     EndScissorMode();
 
     if (GuiButton({ x + width - 120, y + height - 40, 100, 28 }, "Back")) showRecentDialog = false;
+    if (!recentDisks.empty()) {
+        if (GuiButton({ x + 10, y + height - 40, 100, 28 }, "Clear")) modalState = MODAL_CONFIRM_CLEAR_RECENT;
+    }
 }
 
 void UIManager::DrawConfirmDialog(bool& shouldExit, PC88* pc88, CoreRunner* coreRunner) {
@@ -1590,8 +1593,10 @@ void UIManager::DrawConfirmDialog(bool& shouldExit, PC88* pc88, CoreRunner* core
     float x = (float)GetScreenWidth() / 2 - width / 2;
     float y = (float)GetScreenHeight() / 2 - height / 2;
 
-    const char* title = (modalState == MODAL_CONFIRM_RESET) ? "Confirm Reset" : "Confirm Quit";
-    const char* msg = (modalState == MODAL_CONFIRM_RESET) ? "Are you sure you want to reset?" : "Are you sure you want to quit?";
+    const char* title = (modalState == MODAL_CONFIRM_RESET) ? "Confirm Reset"
+        : (modalState == MODAL_CONFIRM_CLEAR_RECENT) ? "Confirm Clear" : "Confirm Quit";
+    const char* msg = (modalState == MODAL_CONFIRM_RESET) ? "Are you sure you want to reset?"
+        : (modalState == MODAL_CONFIRM_CLEAR_RECENT) ? "Clear the recent disks list?" : "Are you sure you want to quit?";
 
     int buttonActive = -1;
     if (GuiMessageBox({ x, y, width, height }, title, msg, "Yes;No", &buttonActive) != RESULT_PRESSED) return;
@@ -1604,6 +1609,11 @@ void UIManager::DrawConfirmDialog(bool& shouldExit, PC88* pc88, CoreRunner* core
             modalState = MODAL_NONE;
         } else if (modalState == MODAL_CONFIRM_QUIT) {
             shouldExit = true;
+            modalState = MODAL_NONE;
+        } else if (modalState == MODAL_CONFIRM_CLEAR_RECENT) {
+            recentDisks.clear();
+            recentScrollOffset = { 0, 0 };
+            SaveRecent();
             modalState = MODAL_NONE;
         }
     }

--- a/src/raylib/disk_dialog.h
+++ b/src/raylib/disk_dialog.h
@@ -36,7 +36,8 @@ public:
     enum ModalState {
         MODAL_NONE,
         MODAL_CONFIRM_RESET,
-        MODAL_CONFIRM_QUIT
+        MODAL_CONFIRM_QUIT,
+        MODAL_CONFIRM_CLEAR_RECENT
     };
 
 private:


### PR DESCRIPTION
## Summary
- Recent Disksダイアログに「Clear」ボタンを追加(履歴が空でない時のみ表示)
- 押すと確認ダイアログ(Yes/No)を表示し、Yesで履歴をクリアして `recent.txt` を保存し直す

## Test plan
- [x] `cmake --build .` でビルドが成功することを確認
- [x] コードレビューでロジックを確認(Recent Disksダイアログの表示・確認モーダルの遷移)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SyPbJCKMgm7PcsMyvyUMta