### PR TITLE
Fix disk mount and drag & drop defects, add write-protect indicator

### DIFF
--- a/src/common/status.cpp
+++ b/src/common/status.cpp
@@ -6,11 +6,20 @@
 #include <stdarg.h>
 #include <stdio.h>
 #include <string.h>
+#include <chrono>
 
 StatusDisplay statusdisplay;
 
+namespace {
+long long NowMs()
+{
+    using namespace std::chrono;
+    return duration_cast<milliseconds>(steady_clock::now().time_since_epoch()).count();
+}
+}
+
 StatusDisplay::StatusDisplay()
-    : priority_(0), duration_ms_(0)
+    : priority_(0), duration_ms_(0), expire_at_ms_(0)
 {
     msg_[0] = 0;
     litstat_[0] = litstat_[1] = litstat_[2] = 0;
@@ -29,7 +38,10 @@ void StatusDisplay::FDAccess(uint dr, bool hd, bool active)
 bool StatusDisplay::Show(int priority, int duration, const char* msg, ...)
 {
     CriticalSection::Lock lock(cs_);
-    if (msg_[0] && priority_ > priority && duration_ms_ > 0)
+    const long long now = NowMs();
+
+    // 表示中で、かつ優先度がより高いメッセージは上書きしない
+    if (msg_[0] && priority_ > priority && now < expire_at_ms_)
         return false;
 
     va_list ap;
@@ -39,6 +51,9 @@ bool StatusDisplay::Show(int priority, int duration, const char* msg, ...)
 
     priority_    = priority;
     duration_ms_ = duration;
+    // duration <= 0 は「期限なし」(毎フレーム更新されるデバッグ表示などが使う)。
+    // ここで now を入れてしまうと初回のポーリングで即座に消えてしまう
+    expire_at_ms_ = (duration > 0) ? now + duration : 0;
     return true;
 }
 
@@ -46,11 +61,25 @@ bool StatusDisplay::GetCurrentMessage(char* dst, size_t cap, int* duration_ms_ou
 {
     CriticalSection::Lock lock(cs_);
     if (!msg_[0] || !dst || cap == 0) return false;
+
+    long long remaining = -1;   // 期限なし
+    if (expire_at_ms_ != 0)
+    {
+        remaining = expire_at_ms_ - NowMs();
+        if (remaining <= 0)
+        {
+            msg_[0]      = 0;
+            priority_    = 0;
+            duration_ms_ = 0;
+            return false;
+        }
+    }
+
     size_t n = strlen(msg_);
     if (n + 1 > cap) n = cap - 1;
     memcpy(dst, msg_, n);
     dst[n] = 0;
-    if (duration_ms_out) *duration_ms_out = duration_ms_;
+    if (duration_ms_out) *duration_ms_out = (int)remaining;
     return true;
 }
 

--- a/src/common/status.h
+++ b/src/common/status.h
@@ -37,7 +37,10 @@ public:
     void Update() {}
 
     // --- Frontend-facing accessors (portable extension) ---
-    // Pull the current message + remaining duration in milliseconds.
+    // Pull the current message + remaining duration in milliseconds
+    // (-1 when the message has no expiry, i.e. it was posted with duration <= 0).
+    // Returns false once the message has expired (the ticker owns the timeout,
+    // so the frontend only has to poll).
     // Thread-safe: takes the internal critical section.
     bool GetCurrentMessage(char* dst, size_t cap, int* duration_ms_out);
 
@@ -47,9 +50,10 @@ public:
 private:
     mutable CriticalSection cs_;
 
-    char    msg_[128];
-    int     priority_;
-    int     duration_ms_;
+    char      msg_[128];
+    int       priority_;
+    int       duration_ms_;
+    long long expire_at_ms_;   // steady clock 基準の失効時刻
 
     int     litstat_[3];   // [0]=FD0, [1]=FD1, [2]=Subsys wait
     int     litcurrent_[3];

--- a/src/pc88/diskmgr.cpp
+++ b/src/pc88/diskmgr.cpp
@@ -480,6 +480,32 @@ bool DiskImageHolder::IsSupportedDisk(int index)
 }
 
 // ---------------------------------------------------------------------------
+//	IsDiskWriteProtected
+//	D88 ヘッダの write-protect フラグだけを見る。
+//	ファイル自体の書き込み可否 (パーミッション等) は対象外。
+//
+bool DiskImageHolder::IsDiskWriteProtected(int index)
+{
+	FileIO* f = GetDisk(index);
+	if (!f)
+		return false;
+
+	if (!f->Seek(0, FileIO::begin))
+		return false;
+
+	ImageHeader ih;
+	memset(&ih, 0, sizeof(ih));
+	if (f->Read(&ih, sizeof(ih)) < 256+16)
+		return false;
+
+	// Raw イメージはヘッダに保護フラグを持たない
+	if (!memcmp(ih.title, "M88 RawDiskImage", 16))
+		return false;
+
+	return ih.readonly != 0;
+}
+
+// ---------------------------------------------------------------------------
 //	SetDiskSize
 //
 bool DiskImageHolder::SetDiskSize(int index, int newsize)
@@ -1113,6 +1139,17 @@ const char* DiskManager::GetImagePath(uint dr) const
 		return drive[dr].holder->GetFileName();
 	}
 	return "";
+}
+
+// ---------------------------------------------------------------------------
+//	指定ディスクの write-protect 状態を取得
+//
+bool DiskManager::IsDiskWriteProtected(uint dr, uint index)
+{
+	CriticalSection::Lock lock(cs);
+	if (dr < max_drives && drive[dr].holder)
+		return drive[dr].holder->IsDiskWriteProtected((int)index);
+	return false;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/pc88/diskmgr.cpp
+++ b/src/pc88/diskmgr.cpp
@@ -109,7 +109,13 @@ static void CopyTitleFromPath(char* dest, size_t destSize, const std::string& pa
 DiskImageHolder::DiskImageHolder()
 {
 	ref = 0;
+	ndisks = 0;
+	readonly = false;
 	playlist = false;
+	quiet = false;
+	// Open() は最初に Connect() で diskname を比較するので、
+	// 未初期化のまま読まれないよう空にしておく
+	diskname[0] = 0;
 }
 
 DiskImageHolder::~DiskImageHolder()
@@ -120,8 +126,10 @@ DiskImageHolder::~DiskImageHolder()
 // ---------------------------------------------------------------------------
 //	�t�@�C�����J��
 //
-bool DiskImageHolder::Open(const char* filename, bool ro, bool create)
+bool DiskImageHolder::Open(const char* filename, bool ro, bool create, bool bequiet)
 {
+	quiet = bequiet;
+
 	// ���Ɏ����Ă���t�@�C�����ǂ������m�F
 	if (Connect(filename))
 		return true;
@@ -150,8 +158,8 @@ bool DiskImageHolder::Open(const char* filename, bool ro, bool create)
 	{
 		if (fio.Open(filename, FileIO::readonly))
 		{
-			if (!readonly)
-				statusdisplay.Show(100, 3000, "�ǎ��p�t�@�C���ł�");
+			if (!readonly && !quiet)
+				statusdisplay.Show(100, 3000, "Read-only image");
 			readonly = true;
 		}
 		else
@@ -159,12 +167,22 @@ bool DiskImageHolder::Open(const char* filename, bool ro, bool create)
 			// �V�����f�B�X�N�C���[�W�H
 			if (!create || !fio.Open(filename, FileIO::create))
 			{
-				statusdisplay.Show(80, 3000, "�f�B�X�N�C���[�W���J���܂���");
+				if (!quiet)
+					statusdisplay.Show(80, 3000, "Cannot open disk image");
 				return false;
 			}
 		}
 	}
-	
+	else if (fio.GetFlags() & FileIO::readonly)
+	{
+		// 書き込みで開けず FileIO が読み込み専用にフォールバックした場合。
+		// ここで拾わないと書き込み可能なイメージとして扱われ、
+		// ゲストからの書き込みが最後まで失敗に気づかれないまま失われる
+		if (!quiet)
+			statusdisplay.Show(100, 3000, "Read-only image");
+		readonly = true;
+	}
+
 	// �t�@�C������o�^
 	strncpy(diskname, filename, MAX_PATH-1);
 	diskname[MAX_PATH-1] = 0;
@@ -239,7 +257,8 @@ bool DiskImageHolder::ReadHeaders()
 		{
 			if (!IsValidHeader(ih))
 			{
-				statusdisplay.Show(90, 3000, "�C���[�W�ɖ����ȃf�[�^���܂܂�Ă��܂�");
+				if (!quiet)
+					statusdisplay.Show(90, 3000, "Image contains invalid data");
 				break;
 			}
 			
@@ -252,7 +271,8 @@ bool DiskImageHolder::ReadHeaders()
 		{
 			if (ndisks != 0)
 			{
-				statusdisplay.Show(80, 3000, "READER �n�f�B�X�N�C���[�W�͘A���ł��܂���");
+				if (!quiet)
+					statusdisplay.Show(80, 3000, "Cannot concatenate READER disk images");
 				return false;
 			}
 
@@ -338,6 +358,7 @@ void DiskImageHolder::Close()
 	diskname[0] = 0;
 	ref = 0;
 	playlist = false;
+	quiet = false;
 }
 
 // ---------------------------------------------------------------------------
@@ -429,6 +450,33 @@ FileIO* DiskImageHolder::GetDisk(int index)
 		return &fio;
 	}
 	return 0;
+}
+
+// ---------------------------------------------------------------------------
+//	IsSupportedDisk
+//	ReadDiskImage() が受け付けるメディアかどうかをマウント前に確認する
+//
+bool DiskImageHolder::IsSupportedDisk(int index)
+{
+	FileIO* f = GetDisk(index);		// playlist ならここで実体が開けるかも判る
+	if (!f)
+		return false;
+
+	if (!f->Seek(0, FileIO::begin))
+		return false;
+
+	ImageHeader ih;
+	memset(&ih, 0, sizeof(ih));
+	// ReadHeaders() と同じく 256+16 を最小サイズとみなす
+	if (f->Read(&ih, sizeof(ih)) < 256+16)
+		return false;
+
+	// Raw イメージは 2D 固定で常に読める
+	if (!memcmp(ih.title, "M88 RawDiskImage", 16))
+		return true;
+
+	// ReadDiskImage() の switch と同じ判定
+	return ih.disktype == 0x00 || ih.disktype == 0x10 || ih.disktype == 0x20;
 }
 
 // ---------------------------------------------------------------------------
@@ -659,7 +707,7 @@ bool DiskManager::Unmount(uint dr)
 		drv.holder = 0;
 	}
 	if (!ret)
-		statusdisplay.Show(50, 3000, "�f�B�X�N�̍X�V�Ɏ��s���܂���");
+		statusdisplay.Show(50, 3000, "Failed to update the disk image");
 	return ret;
 }
 
@@ -694,7 +742,7 @@ bool DiskManager::ReadDiskImage(FileIO* fio, Drive* drive)
 		break;
 
 	default:
-		statusdisplay.Show(90, 3000, "�T�|�[�g���Ă��Ȃ����f�B�A�ł�");
+		statusdisplay.Show(90, 3000, "Unsupported media type");
 		return false;
 	}
 	bool readonly = drive->holder->IsReadOnly() || ih.readonly;
@@ -702,7 +750,7 @@ bool DiskManager::ReadDiskImage(FileIO* fio, Drive* drive)
 	FloppyDisk& disk = drive->disk;
 	if (!disk.Init(type, readonly))
 	{
-		statusdisplay.Show(70, 3000, "��Ɨp�̈�����蓖�Ă邱�Ƃ��ł��܂���ł���");
+		statusdisplay.Show(70, 3000, "Cannot allocate work area");
 		return false;
 	}
 
@@ -715,7 +763,7 @@ bool DiskManager::ReadDiskImage(FileIO* fio, Drive* drive)
 	if (t<164)
 		memset(&ih.trackptr[t], 0, (164-t) * 4);
 	if (t<(uint) Min(160, disk.GetNumTracks()))
-		statusdisplay.Show(80, 3000, "�w�b�_�[�ɖ����ȃf�[�^���܂܂�Ă��܂�");
+		statusdisplay.Show(80, 3000, "Header contains invalid data");
 
 	// trackptr �̂��݂�����
 	uint trackstart = sizeof(ImageHeader);
@@ -795,7 +843,7 @@ bool DiskManager::ReadDiskImageRaw(FileIO* fio, Drive* drive)
 	FloppyDisk& disk = drive->disk;
 	if (!disk.Init(FloppyDisk::MD2D, readonly))
 	{
-		statusdisplay.Show(70, 3000, "��Ɨp�̈�����蓖�Ă邱�Ƃ��ł��܂���ł���");
+		statusdisplay.Show(70, 3000, "Cannot allocate work area");
 		return false;
 	}
 
@@ -981,10 +1029,12 @@ void DiskManager::Update()
 //
 void DiskManager::UpdateDrive(Drive* drv)
 {
+	// holder / sizechanged は UI スレッドの Mount/Unmount から書き換わるため、
+	// 参照する前にロックを取る
+	CriticalSection::Lock lock(cs);
 	if (!drv->holder || drv->sizechanged)
 		return;
 
-	CriticalSection::Lock lock(cs);
 	int t;
 	for (t=0; t<164 && !drv->modified[t]; t++)
 		;
@@ -1005,9 +1055,15 @@ void DiskManager::UpdateDrive(Drive* drv)
 					
 					if (tracksize <= drv->tracksize[t])
 					{
-						drv->modified[t] = false;
 						fio->Seek(drv->trackpos[t], FileIO::begin);
-						WriteTrackImage(fio, drv, t);
+						if (!WriteTrackImage(fio, drv, t))
+						{
+							// 書き込みに失敗したら modified は落とさない。
+							// 落とすと Unmount 時のイメージ全体の書き戻しと
+							// エラー表示まで抑止され、変更が無言で失われる
+							break;
+						}
+						drv->modified[t] = false;
 					}
 					else
 					{
@@ -1097,6 +1153,8 @@ bool DiskManager::AddDisk(uint dr, const char* title, uint type)
 //
 bool DiskManager::FormatDisk(uint dr)
 {
+	if (dr >= max_drives)
+		return false;
 	if (!drive[dr].holder || drive[dr].disk.GetType() != FloppyDisk::MD2D)
 		return false;
 //	statusdisplay.Show(10, 5000, "Format drive : %d", dr);
@@ -1143,8 +1201,8 @@ bool DiskManager::FormatDisk(uint dr)
 			dest += 256;
 		}
 	}
-	drive->sizechanged = true;
-	drive->modified[0] = true;
+	drive[dr].sizechanged = true;
+	drive[dr].modified[0] = true;
 	delete[] buf;
 	return true;
 }

--- a/src/pc88/diskmgr.h
+++ b/src/pc88/diskmgr.h
@@ -49,16 +49,22 @@ public:
 	DiskImageHolder();
 	~DiskImageHolder();
 
-	bool Open(const char* filename, bool readonly, bool create);
+	// quiet: ステータス表示にメッセージを出さない (マウント前の内容確認用)
+	bool Open(const char* filename, bool readonly, bool create, bool quiet = false);
 	bool Connect(const char* filename);
 	bool Disconnect();
 
 	const char* GetTitle(int index);
 	FileIO* GetDisk(int index);
+	// index のディスクが ReadDiskImage() で扱えるメディアかを確認する。
+	// ヘッダしか見ない Open() の後段検証用 (m3u なら実体ファイルの存在も見る)。
+	bool IsSupportedDisk(int index);
 	const char* GetFileName() const { return diskname; }
 	uint GetNumDisks() { return ndisks; }
 	bool SetDiskSize(int index, int newsize);
-	bool IsReadOnly() { return readonly || (playlist && (fio.GetFlags() & FileIO::readonly)); }
+	// FileIO::Open は書き込みで開けなかった場合に読み込み専用へフォールバックするため、
+	// playlist かどうかに関わらず fio のフラグを見ないと書き込み不能を検出できない
+	bool IsReadOnly() { return readonly || (fio.GetFlags() & FileIO::readonly); }
 	uint IsOpen() { return ref > 0; }
 	bool AddDisk(const char* title, uint type);
 
@@ -74,12 +80,13 @@ private:
 	bool ReadPlaylist(const char* filename);
 	void Close();
 	bool IsValidHeader(D88::ImageHeader&);
-	
+
 	FileIO fio;
 	int ndisks;
 	int ref;
 	bool readonly;
 	bool playlist;
+	bool quiet;
 	DiskInfo disks[max_disks];
 	char diskname[MAX_PATH];
 };

--- a/src/pc88/diskmgr.h
+++ b/src/pc88/diskmgr.h
@@ -59,6 +59,9 @@ public:
 	// index のディスクが ReadDiskImage() で扱えるメディアかを確認する。
 	// ヘッダしか見ない Open() の後段検証用 (m3u なら実体ファイルの存在も見る)。
 	bool IsSupportedDisk(int index);
+	// index のディスクに D88 ヘッダの write-protect フラグが立っているか。
+	// ファイル自体の書き込み可否 (パーミッション等) は見ない。
+	bool IsDiskWriteProtected(int index);
 	const char* GetFileName() const { return diskname; }
 	uint GetNumDisks() { return ndisks; }
 	bool SetDiskSize(int index, int newsize);
@@ -112,6 +115,8 @@ public:
 	uint GetNumDisks(uint dr);
 	int GetCurrentDisk(uint dr); 
 	const char* GetImagePath(uint dr) const;
+	// dr の index 枚目に D88 ヘッダの write-protect フラグが立っているか
+	bool IsDiskWriteProtected(uint dr, uint index);
 	bool AddDisk(uint dr, const char* title, uint type);
 	bool IsImageOpen(const char* filename);
 	bool FormatDisk(uint dr);

--- a/src/raylib/app.cpp
+++ b/src/raylib/app.cpp
@@ -322,9 +322,11 @@ int main() {
 #ifdef __HAIKU__
         std::string haikuDroppedPath;
         while (HaikuPollDroppedFile(haikuDroppedPath)) {
-            core.GetUIManager()->MountDisk(core.GetDiskManager(), haikuDroppedPath.c_str(), 0, 1, false);
-            if (Config::Get().flag2 & PC8801::Config::resetondrop) {
-                core.RequestReset();
+            // マウントに失敗した場合はディスクが入れ替わっていないのでリセットしない
+            if (core.GetUIManager()->MountDisk(core.GetDiskManager(), haikuDroppedPath.c_str(), 0, 1, false)) {
+                if (Config::Get().flag2 & PC8801::Config::resetondrop) {
+                    core.RequestReset();
+                }
             }
         }
 #endif
@@ -332,9 +334,11 @@ int main() {
         if (IsFileDropped()) {
             FilePathList droppedFiles = LoadDroppedFiles();
             if (droppedFiles.count > 0) {
-                core.GetUIManager()->MountDisk(core.GetDiskManager(), droppedFiles.paths[0], 0, 1, false);
-                if (Config::Get().flag2 & PC8801::Config::resetondrop) {
-                    core.RequestReset();
+                // マウントに失敗した場合はディスクが入れ替わっていないのでリセットしない
+                if (core.GetUIManager()->MountDisk(core.GetDiskManager(), droppedFiles.paths[0], 0, 1, false)) {
+                    if (Config::Get().flag2 & PC8801::Config::resetondrop) {
+                        core.RequestReset();
+                    }
                 }
             }
             UnloadDroppedFiles(droppedFiles);

--- a/src/raylib/core_runner.cpp
+++ b/src/raylib/core_runner.cpp
@@ -229,17 +229,29 @@ bool CoreRunner::LoadState(const std::string& path, std::string* message) {
             ApplyConfig(&cfg);
             Reset();
 
+            // 壊れたファイルで巨大な確保をしないよう検証する
+            if (ssh.datasize <= 0 || ssh.datasize > 64 * 1024 * 1024) {
+                if (message) *message = "Failed to load state";
+                return false;
+            }
+
             std::vector<uint8> state((size_t)ssh.datasize);
             bool dataRead = false;
             if (ssh.flags & 0x80000000u) {
                 int32 csize = 0;
                 if (file.Read(&csize, 4) == 4 && csize < 0) {
-                    csize = -csize;
-                    std::vector<uint8> compressed((size_t)csize);
-                    if (file.Read(compressed.data(), csize) == csize) {
-                        uLongf destSize = (uLongf)ssh.datasize;
-                        dataRead = uncompress(state.data(), &destSize, compressed.data(), (uLongf)csize) == Z_OK
-                                && destSize == (uLongf)ssh.datasize;
+                    // int32 のまま反転すると INT32_MIN で符号が戻らないので
+                    // 64bit で受けてから圧縮後サイズの上限で検証する。
+                    // 上限を掛けないと壊れたファイルで巨大な確保に走り、
+                    // bad_alloc が catch されずプロセスごと落ちる。
+                    long long len = -(long long)csize;
+                    if (len > 0 && len <= (long long)compressBound((uLong)ssh.datasize)) {
+                        std::vector<uint8> compressed((size_t)len);
+                        if (file.Read(compressed.data(), (int32)len) == (int32)len) {
+                            uLongf destSize = (uLongf)ssh.datasize;
+                            dataRead = uncompress(state.data(), &destSize, compressed.data(), (uLongf)len) == Z_OK
+                                    && destSize == (uLongf)ssh.datasize;
+                        }
                     }
                 }
             } else {
@@ -249,6 +261,31 @@ bool CoreRunner::LoadState(const std::string& path, std::string* message) {
             if (dataRead) {
                 if (devlist.LoadStatus(state.data())) {
                     ok = true;
+
+                    // 保存時に挿入されていたディスク番号へ戻す。
+                    // イメージのパスはスナップショットに含まれないので、
+                    // 同じイメージが開かれている場合のみ復元できる。
+                    //
+                    // 現在の状態は必ずループの前に採取する: Mount() は同じ
+                    // holder の同じ index を掴んでいる他のドライブを
+                    // Unmount() するため、1 台目を復元した時点で 2 台目の
+                    // GetImagePath() が空になり復元できなくなる。
+                    std::string imagePath[2];
+                    int imageDisks[2];
+                    int currentDisk[2];
+                    for (uint i = 0; i < 2; i++) {
+                        imagePath[i]   = diskmgr.GetImagePath(i);
+                        imageDisks[i]  = (int)diskmgr.GetNumDisks(i);
+                        currentDisk[i] = diskmgr.GetCurrentDisk(i);
+                    }
+                    for (uint i = 0; i < 2; i++) {
+                        if (imagePath[i].empty()) continue;
+                        if (currentDisk[i] == ssh.disk[i]) continue;
+                        // 保存時より枚数の少ないイメージが入っている場合は
+                        // マウントに失敗して空になるだけなので触らない
+                        if (ssh.disk[i] >= imageDisks[i]) continue;
+                        diskmgr.Mount(i, imagePath[i].c_str(), false, ssh.disk[i], false);
+                    }
                 } else {
                     Reset();
                 }
@@ -381,6 +418,10 @@ void CoreRunner::Run() {
             TimeSync();
             actualTicks = Proceed(ticksToRun, clockParam, speedParam);
             UpdateScreen(true);
+
+            // 変更のあったトラックをイメージへ書き戻す。これを回さないと
+            // 書き込みはアンマウント/終了時までディスクに反映されない
+            diskmgr.Update();
         }
 
         totalTicksEmulated += actualTicks;

--- a/src/raylib/disk_dialog.cpp
+++ b/src/raylib/disk_dialog.cpp
@@ -278,6 +278,9 @@ static std::string TrimDiskTitle(const char* raw) {
     return s;
 }
 
+// 書き込み禁止マークの鍵のサイズ。raygui のアイコン素の大きさ (16px) の 90%。
+static const float kKeyIconSize = 16.0f * 0.9f;
+
 static std::string StripExtension(std::string name) {
     size_t dot = name.find_last_of('.');
     if (dot != std::string::npos) {
@@ -300,6 +303,9 @@ UIManager::UIManager() :
     currentStateSlot(0),
     diskScrollOffset({ 0, 0 }),
     recentScrollOffset({ 0, 0 }),
+    wpCacheDrive(-1),
+    statusWriteProtect{ false, false },
+    statusWpIndex{ -1, -1 },
     windowScale(0), isFullscreen(false),
     basicModeEdit(false), windowScaleEdit(false),
     cpuModeEdit(false), port44Edit(false), portA8Edit(false), samplingEdit(false), keyboardEdit(false),
@@ -317,6 +323,8 @@ UIManager::UIManager() :
     statePreviewTexture = {0};
     fontJp = {0};
     fontEn = {0};
+    keyIconTexture = {0};
+    keyIconReady = false;
     LoadRecent();
 #ifndef __HAIKU__
     NFD_Init();
@@ -326,6 +334,7 @@ UIManager::UIManager() :
 UIManager::~UIManager() {
     SaveRecent();
     if (IsTextureValid(statePreviewTexture)) UnloadTexture(statePreviewTexture);
+    if (keyIconReady) UnloadRenderTexture(keyIconTexture);
 #ifndef __HAIKU__
     NFD_Quit();
 #endif
@@ -384,10 +393,34 @@ void UIManager::Init() {
         GuiSetStyle(DEFAULT, TEXT_SPACING, 1);
     }
 
+    // 書き込み禁止マークの鍵を等倍 (16px) で焼いておく。
+    // GuiDrawIcon の pixelSize は整数倍しか受け付けないため、
+    // 小数倍で出したい場合はここから縮小して描く。
+    keyIconTexture = LoadRenderTexture(16, 16);
+    if (IsRenderTextureValid(keyIconTexture)) {
+        BeginTextureMode(keyIconTexture);
+        ClearBackground(BLANK);
+        GuiDrawIcon(ICON_KEY, 0, 0, 1, WHITE);
+        EndTextureMode();
+        SetTextureFilter(keyIconTexture.texture, TEXTURE_FILTER_BILINEAR);
+        keyIconReady = true;
+    }
+
     int h = GetScreenHeight();
     if (h >= 1224) windowScale = 2;
     else if (h >= 824) windowScale = 1;
     else windowScale = 0;
+}
+
+void UIManager::DrawKeyIcon(float x, float y, float size, Color color) const {
+    if (keyIconReady) {
+        // RenderTexture は上下反転して格納されるので src の height を負にする
+        Rectangle src = { 0, 0, (float)keyIconTexture.texture.width,
+                                -(float)keyIconTexture.texture.height };
+        DrawTexturePro(keyIconTexture.texture, src, { x, y, size, size }, { 0, 0 }, 0.0f, color);
+    } else {
+        GuiDrawIcon(ICON_KEY, (int)x, (int)y, 1, color);
+    }
 }
 
 void UIManager::Update(bool& shouldExit, PC88* pc88, CoreRunner* coreRunner) {
@@ -554,6 +587,54 @@ void UIManager::OpenBothDrives(DiskManager* diskmgr) {
     }
 }
 
+// セレクタに並ぶ各ディスクの write-protect 状態を取り直す。
+// 判定はイメージのヘッダ読み込み (m3u なら実体を開く) を伴うため、
+// 対象ドライブ・イメージ・枚数が変わったときだけ引き直す。
+void UIManager::RefreshWriteProtectCache(DiskManager* diskmgr) {
+    if (selectingDiskForDrive < 0) {
+        wpCacheDrive = -1;
+        wpCachePath.clear();
+        diskWriteProtect.clear();
+        return;
+    }
+
+    std::string path = diskmgr->GetImagePath(selectingDiskForDrive);
+    int numDisks = (int)diskmgr->GetNumDisks(selectingDiskForDrive);
+    if (wpCacheDrive == selectingDiskForDrive && wpCachePath == path &&
+        (int)diskWriteProtect.size() == numDisks) {
+        return;
+    }
+
+    diskWriteProtect.assign((size_t)numDisks, 0);
+    for (int i = 0; i < numDisks; i++) {
+        diskWriteProtect[i] = diskmgr->IsDiskWriteProtected(selectingDiskForDrive, i) ? 1 : 0;
+    }
+    wpCacheDrive = selectingDiskForDrive;
+    wpCachePath = path;
+}
+
+// 挿入中のディスクの write-protect 状態。ステータスバーは毎フレーム描かれるので、
+// 対象ディスク (パス + 枚番号) が変わったときだけ引き直す。
+bool UIManager::IsCurrentDiskWriteProtected(DiskManager* diskmgr, int drive) {
+    if (drive < 0 || drive >= 2) return false;
+
+    int index = diskmgr->GetCurrentDisk(drive);
+    if (index < 0) {
+        statusWpIndex[drive] = -1;
+        statusWpPath[drive].clear();
+        statusWriteProtect[drive] = false;
+        return false;
+    }
+
+    std::string path = diskmgr->GetImagePath(drive);
+    if (statusWpIndex[drive] != index || statusWpPath[drive] != path) {
+        statusWpIndex[drive] = index;
+        statusWpPath[drive] = path;
+        statusWriteProtect[drive] = diskmgr->IsDiskWriteProtected((uint)drive, (uint)index);
+    }
+    return statusWriteProtect[drive];
+}
+
 void UIManager::DrawDiskSelector(DiskManager* diskmgr) {
     float width = 320;
     float height = 340;
@@ -564,6 +645,8 @@ void UIManager::DrawDiskSelector(DiskManager* diskmgr) {
     if (GuiWindowBox({ x, y, width, height }, title.c_str())) selectingDiskForDrive = -1;
 
     int numDisks = diskmgr->GetNumDisks(selectingDiskForDrive);
+    RefreshWriteProtectCache(diskmgr);
+
     float btnY = y + 40;
     float btnH = 26;
 
@@ -594,6 +677,13 @@ void UIManager::DrawDiskSelector(DiskManager* diskmgr) {
 
         std::string label = std::to_string(i + 1) + ": " + dLabel;
         if (GuiButton({ view.x, itemY, content.width, btnH }, label.c_str())) chosen = i;
+
+        // 書き込み禁止 (D88 ヘッダの write-protect) なら右端に鍵を出す
+        if (i < (int)diskWriteProtect.size() && diskWriteProtect[i]) {
+            DrawKeyIcon(view.x + content.width - kKeyIconSize - 6,
+                        itemY + (btnH - kKeyIconSize) / 2.0f,
+                        kKeyIconSize, StyleColor(BUTTON, TEXT_COLOR_NORMAL));
+        }
 
         if (isJp && IsFontValid(fontEn)) {
             GuiSetFont(fontEn);
@@ -1356,15 +1446,39 @@ void UIManager::DrawStatusBar(DiskManager* diskmgr) {
     Color ledOff = StyleFade(STATUSBAR, BORDER_COLOR_FOCUSED, 0.25f);
     Color statusText = StyleColor(STATUSBAR, TEXT_COLOR_NORMAL);
 
+    // タイトルを描き、書き込み禁止ならその右に鍵を出す。
+    // slotEndX はこのドライブの表示枠の右端 (隣の要素の手前)。
+    // 枠は 16 文字のタイトルでほぼ埋まるので、はみ出しはクリップで抑え、
+    // 鍵の分の幅を先に確保してから描く。
+    auto drawTitle = [&](const std::string& text, float titleX, float slotEndX, bool writeProtected) {
+        float textLimit = writeProtected ? (slotEndX - kKeyIconSize - 4) : slotEndX;
+
+        float textW;
+        BeginScissorMode((int)titleX, (int)(sH - 24), (int)(textLimit - titleX), 24);
+        if (ContainsJapanese(text) && IsFontValid(fontJp)) {
+            DrawTextEx(fontJp, text.c_str(), { titleX, sH - 21 }, 16, 1, statusText);
+            textW = MeasureTextEx(fontJp, text.c_str(), 16, 1).x;
+        } else {
+            DrawEnText(text.c_str(), (int)titleX, (int)textY, statusText);
+            textW = (float)MeasureEnText(text.c_str());
+        }
+        EndScissorMode();
+
+        if (!writeProtected) return;
+
+        // 通常はタイトルの直後。収まらない場合は確保した右端に固定する
+        float iconX = titleX + textW + 4;
+        if (iconX > textLimit) iconX = textLimit;
+        float iconY = sH - 24.0f + (24.0f - kKeyIconSize) / 2.0f;
+        DrawKeyIcon(iconX, iconY, kKeyIconSize, statusText);
+    };
+
     Color l1 = (statusdisplay.GetFDState(1) & 1) ? ledOn : ledOff;
     DrawCircle(15, (int)centerY, 4, l1);
 
     DrawEnText("FDD2:", 25, (int)textY, statusText);
-    if (ContainsJapanese(t1) && IsFontValid(fontJp)) {
-        DrawTextEx(fontJp, t1.c_str(), { 75, sH - 21 }, 16, 1, statusText);
-    } else {
-        DrawEnText(t1.c_str(), 75, (int)textY, statusText);
-    }
+    // 右隣は FDD1 の LED (x=215, r=4) なのでその左端の手前まで
+    drawTitle(t1, 75, 209, IsCurrentDiskWriteProtected(diskmgr, 1));
 
     int d0 = diskmgr->GetCurrentDisk(0);
     const char* t0_raw = (d0 >= 0) ? diskmgr->GetImageTitle(0, d0) : nullptr;
@@ -1375,11 +1489,8 @@ void UIManager::DrawStatusBar(DiskManager* diskmgr) {
     DrawCircle(215, (int)centerY, 4, l0);
 
     DrawEnText("FDD1:", 225, (int)textY, statusText);
-    if (ContainsJapanese(t0) && IsFontValid(fontJp)) {
-        DrawTextEx(fontJp, t0.c_str(), { 275, sH - 21 }, 16, 1, statusText);
-    } else {
-        DrawEnText(t0.c_str(), 275, (int)textY, statusText);
-    }
+    // 右隣は BASIC モード表示 (sW - 200) なのでその手前まで
+    drawTitle(t0, 275, sW - 200 - 4, IsCurrentDiskWriteProtected(diskmgr, 0));
 
     const auto& cfg = Config::Get();
     std::string modeStr = "Unknown";

--- a/src/raylib/disk_dialog.cpp
+++ b/src/raylib/disk_dialog.cpp
@@ -206,16 +206,19 @@ static std::string NormalizeSelectedPath(const char* rawPath) {
     }
 
     const std::string filePrefix = "file://";
-    if (path.rfind(filePrefix, 0) == 0) {
-        std::string rest = path.substr(filePrefix.size());
-        const std::string localhost = "localhost";
-        if (rest.rfind(localhost, 0) == 0) {
-            rest.erase(0, localhost.size());
-        }
-        if (rest.empty() || rest[0] != '/') {
-            rest.insert(rest.begin(), '/');
-        }
-        path = rest;
+    if (path.rfind(filePrefix, 0) != 0) {
+        // 素のファイルパス。ここで percent-decode すると "SAVE%20DATA.d88" の
+        // ようにリテラルで %XX を含むファイル名が壊れる
+        return path;
+    }
+
+    path.erase(0, filePrefix.size());
+    const std::string localhost = "localhost";
+    if (path.rfind(localhost, 0) == 0) {
+        path.erase(0, localhost.size());
+    }
+    if (path.empty() || path[0] != '/') {
+        path.insert(path.begin(), '/');
     }
 
     return PercentDecodePath(path);
@@ -261,6 +264,20 @@ static const char* GetFileNameOnly(const char* path) {
     return f ? f + 1 : path;
 }
 
+// D88 のディスクタイトルは 16 バイト固定長で、NUL や空白が詰められている。
+// find_last_not_of(" \0", n) は探索集合が C 文字列として解釈されるため実際には
+// " " だけになり埋め込み NUL を落とせない。明示的に切り詰める。
+static std::string TrimDiskTitle(const char* raw) {
+    if (!raw) return std::string();
+    size_t len = 0;
+    while (len < 16 && raw[len]) len++;
+    std::string s(raw, len);
+    size_t last = s.find_last_not_of(' ');
+    if (last == std::string::npos) return std::string();
+    s.resize(last + 1);
+    return s;
+}
+
 static std::string StripExtension(std::string name) {
     size_t dot = name.find_last_of('.');
     if (dot != std::string::npos) {
@@ -290,10 +307,11 @@ UIManager::UIManager() :
     volFmEdit(false), volSsgEdit(false), volAdpcmEdit(false), volRhythmEdit(false),
     mouseSensEdit(false),
     bufferVal(100), mouseSensVal(10),
+    systemScroll({ 0, 0 }),
     mixerScroll({ 0, 0 }),
     inputScroll({ 0, 0 }),
-    resetPending(false),
-    lastAccessedDir("")
+    lastAccessedDir(""),
+    resetPending(false)
 {
     for (int i = 0; i < 6; i++) volRhythmDetailEdit[i] = false;
     statePreviewTexture = {0};
@@ -400,6 +418,9 @@ void UIManager::Draw(DiskManager* diskmgr, PC8801::Config& cfg, PC88* pc88, Core
         else if (showSettings) DrawSettings(cfg, pc88, coreRunner);
         else DrawMainMenu(diskmgr, pc88, shouldExit, coreRunner);
     }
+
+    // メニューやモーダルより手前に出す
+    DrawOSDMessage();
 }
 
 void UIManager::ToggleMenu(CoreRunner* coreRunner) {
@@ -456,10 +477,8 @@ void UIManager::DrawMainMenu(DiskManager* diskmgr, PC88* pc88, bool& shouldExit,
         int diskIdx = diskmgr->GetCurrentDisk(i);
         std::string label;
         if (diskIdx >= 0) {
-            const char* title = diskmgr->GetImageTitle(i, diskIdx);
-            label = Paths::SJIStoUTF8(title ? std::string(title, 16) : "");
-            size_t last = label.find_last_not_of(" \0", label.length());
-            if (last != std::string::npos) label = label.substr(0, last + 1);
+            label = Paths::SJIStoUTF8(TrimDiskTitle(diskmgr->GetImageTitle(i, diskIdx)));
+            if (label.empty()) label = std::string("Drive ") + std::to_string(i + 1) + ": (No Title)";
         } else {
             label = std::string("Drive ") + std::to_string(i + 1) + ": Empty";
         }
@@ -553,15 +572,19 @@ void UIManager::DrawDiskSelector(DiskManager* diskmgr) {
 
     GuiScrollPanel(view, NULL, { 0, 0, content.width, content.height }, &diskScrollOffset, &view);
 
+    // 選択はループ内で処理しない。selectingDiskForDrive を書き換えると
+    // 残りの項目が別ドライブのタイトルで描かれてしまうため、
+    // 描画を終えてから確定させる。
+    int chosen = -1;
+
     BeginScissorMode((int)view.x, (int)view.y, (int)view.width, (int)view.height);
     for (int i = 0; i < numDisks; i++) {
         float itemY = view.y + i * (btnH + 4) + diskScrollOffset.y;
         if (itemY + btnH < view.y || itemY > view.y + view.height) continue;
 
-        const char* dTitle = diskmgr->GetImageTitle(selectingDiskForDrive, i);
-        std::string dLabel = dTitle ? Paths::NormalizeNFC(Paths::SJIStoUTF8(std::string(dTitle, 16))) : "(No Title)";
-        size_t last = dLabel.find_last_not_of(" \0", dLabel.length());
-        if (last != std::string::npos) dLabel = dLabel.substr(0, last + 1);
+        std::string dLabel = Paths::NormalizeNFC(
+            Paths::SJIStoUTF8(TrimDiskTitle(diskmgr->GetImageTitle(selectingDiskForDrive, i))));
+        if (dLabel.empty()) dLabel = "(No Title)";
 
         bool isJp = ContainsJapanese(dLabel);
         if (isJp && IsFontValid(fontJp)) {
@@ -570,19 +593,7 @@ void UIManager::DrawDiskSelector(DiskManager* diskmgr) {
         }
 
         std::string label = std::to_string(i + 1) + ": " + dLabel;
-
-        if (GuiButton({ view.x, itemY, content.width, btnH }, label.c_str())) {
-            std::string currentPath = diskmgr->GetImagePath(selectingDiskForDrive);
-            if (!currentPath.empty()) {
-                diskmgr->Mount(selectingDiskForDrive, currentPath.c_str(), false, i, false);
-            }
-            if (selectingBothDrives && selectingDiskForDrive == 0) {
-                selectingDiskForDrive = 1;
-            } else {
-                selectingDiskForDrive = -1;
-                selectingBothDrives = false;
-            }
-        }
+        if (GuiButton({ view.x, itemY, content.width, btnH }, label.c_str())) chosen = i;
 
         if (isJp && IsFontValid(fontEn)) {
             GuiSetFont(fontEn);
@@ -590,6 +601,19 @@ void UIManager::DrawDiskSelector(DiskManager* diskmgr) {
         }
     }
     EndScissorMode();
+
+    if (chosen >= 0) {
+        std::string currentPath = diskmgr->GetImagePath(selectingDiskForDrive);
+        if (!currentPath.empty()) {
+            diskmgr->Mount(selectingDiskForDrive, currentPath.c_str(), false, chosen, false);
+        }
+        if (selectingBothDrives && selectingDiskForDrive == 0) {
+            selectingDiskForDrive = 1;
+        } else {
+            selectingDiskForDrive = -1;
+            selectingBothDrives = false;
+        }
+    }
 
     if (GuiButton({ x + width - 120, y + height - 40, 100, 28 }, "Back")) {
         if (selectingBothDrives && selectingDiskForDrive == 1) {
@@ -1325,11 +1349,8 @@ void UIManager::DrawStatusBar(DiskManager* diskmgr) {
 
     int d1 = diskmgr->GetCurrentDisk(1);
     const char* t1_raw = (d1 >= 0) ? diskmgr->GetImageTitle(1, d1) : nullptr;
-    std::string t1 = (t1_raw) ? Paths::NormalizeNFC(Paths::SJIStoUTF8(std::string(t1_raw, 16))) : "Empty";
-    if (t1_raw) {
-        size_t last = t1.find_last_not_of(" \0", t1.length());
-        if (last != std::string::npos) t1 = t1.substr(0, last + 1);
-    }
+    std::string t1 = t1_raw ? Paths::NormalizeNFC(Paths::SJIStoUTF8(TrimDiskTitle(t1_raw))) : "Empty";
+    if (t1.empty()) t1 = "(No Title)";
 
     Color ledOn = StyleColor(STATUSBAR, BORDER_COLOR_FOCUSED);
     Color ledOff = StyleFade(STATUSBAR, BORDER_COLOR_FOCUSED, 0.25f);
@@ -1347,11 +1368,8 @@ void UIManager::DrawStatusBar(DiskManager* diskmgr) {
 
     int d0 = diskmgr->GetCurrentDisk(0);
     const char* t0_raw = (d0 >= 0) ? diskmgr->GetImageTitle(0, d0) : nullptr;
-    std::string t0 = (d0 >= 0) ? Paths::NormalizeNFC(Paths::SJIStoUTF8(std::string(t0_raw, 16))) : "Empty";
-    if (t0_raw) {
-        size_t last = t0.find_last_not_of(" \0", t0.length());
-        if (last != std::string::npos) t0 = t0.substr(0, last + 1);
-    }
+    std::string t0 = t0_raw ? Paths::NormalizeNFC(Paths::SJIStoUTF8(TrimDiskTitle(t0_raw))) : "Empty";
+    if (t0.empty()) t0 = "(No Title)";
 
     Color l0 = (statusdisplay.GetFDState(0) & 1) ? ledOn : ledOff;
     DrawCircle(215, (int)centerY, 4, l0);
@@ -1380,9 +1398,55 @@ void UIManager::DrawStatusBar(DiskManager* diskmgr) {
     DrawEnText(TextFormat("%d FPS", GetFPS()), (int)sW - 80, (int)textY, statusText);
 }
 
-void UIManager::MountDisk(DiskManager* diskmgr, const char* path, int img1, int img2, bool openSelectorIfNeeded) {
+// コア側 (statusdisplay) が投げた一時メッセージをステータスバーの上に表示する。
+// これが無いとマウント失敗などのエラーがユーザーに一切伝わらない。
+void UIManager::DrawOSDMessage() {
+    char msg[128];
+    int remaining = 0;
+    if (!statusdisplay.GetCurrentMessage(msg, sizeof(msg), &remaining)) return;
+    if (!msg[0]) return;
+
+    const float sW = (float)GetScreenWidth();
+    const float sH = (float)GetScreenHeight();
+
+    bool isJp = ContainsJapanese(msg);
+    bool useJpFont = isJp && IsFontValid(fontJp);
+    Font font = useJpFont ? fontJp : fontEn;
+    float fontSize = useJpFont ? 15.0f : 16.0f;
+    float textW = IsFontValid(font) ? MeasureTextEx(font, msg, fontSize, 1).x
+                                    : (float)MeasureText(msg, 10);
+
+    const float padX = 8.0f;
+    const float boxH = 22.0f;
+    float boxW = textW + padX * 2;
+    if (boxW > sW - 20.0f) boxW = sW - 20.0f;
+
+    const float x = 10.0f;
+    const float y = sH - 24.0f - boxH - 4.0f;
+
+    // 消える直前だけフェードアウトさせる (remaining < 0 は期限なし)
+    float alpha = (remaining >= 0 && remaining < 300) ? (float)remaining / 300.0f : 1.0f;
+
+    Color bg = StyleColor(DEFAULT, BACKGROUND_COLOR);
+    bg.a = (unsigned char)(220 * alpha);
+    Color border = StyleFade(DEFAULT, LINE_COLOR, alpha);
+    Color text = StyleFade(DEFAULT, TEXT_COLOR_NORMAL, alpha);
+
+    DrawRectangleRec({ x, y, boxW, boxH }, bg);
+    DrawRectangleLinesEx({ x, y, boxW, boxH }, 1, border);
+
+    BeginScissorMode((int)(x + padX), (int)y, (int)(boxW - padX * 2), (int)boxH);
+    if (IsFontValid(font)) {
+        DrawTextEx(font, msg, { x + padX, y + (boxH - fontSize) / 2 }, fontSize, 1, text);
+    } else {
+        DrawText(msg, (int)(x + padX), (int)(y + 6), 10, text);
+    }
+    EndScissorMode();
+}
+
+bool UIManager::MountDisk(DiskManager* diskmgr, const char* path, int img1, int img2, bool openSelectorIfNeeded) {
     std::string mountPath = NormalizeSelectedPath(path);
-    if (mountPath.empty()) return;
+    if (mountPath.empty()) return false;
 
     const char* diskPath = mountPath.c_str();
 #ifdef __HAIKU__
@@ -1393,23 +1457,56 @@ void UIManager::MountDisk(DiskManager* diskmgr, const char* path, int img1, int 
     int origImg1 = img1;
     int origImg2 = img2;
 
-    // Update last accessed directory
-    lastAccessedDir = GetDirFromPath(diskPath);
-
-    // When a selector may be shown, peek at how many disks the image holds
-    // *before* touching either drive, so a multi-disk image (e.g. a .m3u
-    // playlist) doesn't get a disk inserted ahead of the user's choice.
+    // Peek at the image *before* touching either drive. DiskManager::Mount
+    // ejects the target drive as its very first step, so without this an
+    // unsupported file (a stray drag & drop, a stale recent entry) would
+    // throw away whatever the user had inserted. The probe is quiet so its
+    // failure doesn't post a message for a mount we never attempted.
+    // It also tells us how many disks the image holds, so a multi-disk image
+    // (e.g. a .m3u playlist) doesn't get a disk inserted ahead of the user's
+    // choice in the selector.
+    //
     // Drag & drop never shows the selector (openSelectorIfNeeded is false),
     // so it keeps mounting the requested indices immediately, unaffected.
     int peekedImages = 0;
-    if (openSelectorIfNeeded) {
+    bool needsSelector = false;
+    {
         DiskImageHolder probe;
-        if (probe.Open(diskPath, true, false)) {
-            peekedImages = (int)probe.GetNumDisks();
+        if (!probe.Open(diskPath, true, false, /*quiet*/ true)) {
+#ifdef __HAIKU__
+            std::fprintf(stderr, "M88M: disk mount failed (probe): %s\n", diskPath);
+#endif
+            statusdisplay.Show(100, 3000, "Disk mount failed: %.96s", GetFileNameOnly(diskPath));
+            return false;
+        }
+        peekedImages = (int)probe.GetNumDisks();
+        needsSelector = openSelectorIfNeeded &&
+            peekedImages > ((origImg1 >= 0 && origImg2 >= 0) ? 2 : 1);
+
+        // Open() はヘッダしか見ないので、実際に挿入する枚のメディア種別まで
+        // ここで確認する。これが無いと「1 枚目は読めるが 2 枚目が未対応」の
+        // イメージで Drive 1 だけ差し替わり Drive 2 が排出されたまま残る。
+        // 衝突回避で index が -1 に落ちる枚は「既に他ドライブで読めている」
+        // ものなので、まとめて検証しても誤判定にはならない。
+        if (!needsSelector) {
+            const int wanted[2] = { origImg1, origImg2 };
+            for (int w = 0; w < 2; w++) {
+                if (wanted[w] < 0 || wanted[w] >= peekedImages) continue;
+                if (probe.IsSupportedDisk(wanted[w])) continue;
+#ifdef __HAIKU__
+                std::fprintf(stderr, "M88M: unsupported disk %d in %s\n", wanted[w], diskPath);
+#endif
+                statusdisplay.Show(100, 3000, "Unsupported disk image: %.96s", GetFileNameOnly(diskPath));
+                return false;
+            }
         }
     }
-    bool needsSelector = openSelectorIfNeeded &&
-        peekedImages > ((origImg1 >= 0 && origImg2 >= 0) ? 2 : 1);
+
+    // Update last accessed directory
+    lastAccessedDir = GetDirFromPath(diskPath);
+
+    // 要求したドライブが実際にマウントできたか (成功判定用)
+    bool mountedAll = true;
 
     // Mount Drive 1
     if (img1 >= 0) {
@@ -1421,6 +1518,8 @@ void UIManager::MountDisk(DiskManager* diskmgr, const char* path, int img1, int 
         if (diskmgr->Mount(0, diskPath, false, mountIndex, false)) {
             success = true;
             availableImages = (int)diskmgr->GetNumDisks(0);
+        } else {
+            mountedAll = false;
         }
     }
 
@@ -1435,18 +1534,22 @@ void UIManager::MountDisk(DiskManager* diskmgr, const char* path, int img1, int 
             if (diskmgr->Mount(1, diskPath, false, mountIndex, false)) {
                 success = true;
                 availableImages = (int)diskmgr->GetNumDisks(1);
+            } else {
+                mountedAll = false;
             }
         } else if (needsSelector) {
             // Both drives specified but a selector will be shown: attach
             // Drive 2 to the same image without inserting a disk, so the
             // selector can enumerate it once the user moves on from Drive 1.
-            diskmgr->Mount(1, diskPath, false, -1, false);
+            if (!diskmgr->Mount(1, diskPath, false, -1, false)) mountedAll = false;
         } else {
             // Both drives specified (Drive 1&2 auto-mount behavior)
             //availableImages should be set from Drive 1 mount above
             if (img2 < availableImages) {
                 if (diskmgr->Mount(1, diskPath, false, img2, false)) {
                     success = true;
+                } else {
+                    mountedAll = false;
                 }
             } else {
                 // No second image available, explicitly eject Drive 2
@@ -1459,7 +1562,8 @@ void UIManager::MountDisk(DiskManager* diskmgr, const char* path, int img1, int 
 #ifdef __HAIKU__
         std::fprintf(stderr, "M88M: disk mounted: %s\n", diskPath);
 #endif
-        AddRecent(mountPath);
+        // 要求したドライブが全部マウントできたときだけ履歴に残す
+        if (mountedAll) AddRecent(mountPath);
         // If mounting to only one drive, show selector if multiple images exist
         if (!openSelectorIfNeeded) {
             selectingDiskForDrive = -1;
@@ -1485,8 +1589,10 @@ void UIManager::MountDisk(DiskManager* diskmgr, const char* path, int img1, int 
 #ifdef __HAIKU__
         std::fprintf(stderr, "M88M: disk mount failed: %s\n", diskPath);
 #endif
-        statusdisplay.Show(100, 3000, "Disk mount failed: %.96s", diskPath);
+        statusdisplay.Show(100, 3000, "Disk mount failed: %.96s", GetFileNameOnly(diskPath));
     }
+
+    return success && mountedAll;
 }
 
 void UIManager::OpenNativeDialog(DiskManager* diskmgr, int drive) {
@@ -1526,14 +1632,14 @@ void UIManager::LoadRecent() {
     std::string path = Paths::GetConfigDir() + "/recent.txt";
     FileIO fio;
     if (fio.Open(path.c_str(), FileIO::readonly)) {
-        std::vector<char> buf(fio.Tellp() + 1024); // Size of file if we knew it
-        // Since FileIO doesn't have a GetSize, but we can Seek to end
+        // FileIO には GetSize が無いので末尾までシークして求める
         fio.Seek(0, FileIO::end);
         int32 size = fio.Tellp();
         fio.Seek(0, FileIO::begin);
+        if (size <= 0) return;
 
         std::string content;
-        content.resize(size);
+        content.resize((size_t)size);
         fio.Read(&content[0], size);
 
         std::string line;

--- a/src/raylib/disk_dialog.h
+++ b/src/raylib/disk_dialog.h
@@ -16,7 +16,11 @@ public:
     void Draw(DiskManager* diskmgr, PC8801::Config& cfg, class PC88* pc88, class CoreRunner* coreRunner, bool& shouldExit);
     void OpenNativeDialog(DiskManager* diskmgr, int drive);
     void OpenBothDrives(DiskManager* diskmgr);
-    void MountDisk(DiskManager* diskmgr, const char* path, int img1, int img2, bool openSelectorIfNeeded = true);
+    // 要求したドライブすべてのマウントに成功したときだけ true。
+    // イメージが開けない場合や、挿入する枚が未対応メディア / m3u の実体欠落
+    // だった場合は、ドライブに一切触れずに false を返す。
+    // (セレクタを出す場合にユーザーが後から選ぶ枚は検証対象外)
+    bool MountDisk(DiskManager* diskmgr, const char* path, int img1, int img2, bool openSelectorIfNeeded = true);
     void AddRecent(const std::string& path);
     void LoadRecent();
     void SaveRecent();
@@ -49,6 +53,7 @@ private:
     void DrawConfirmDialog(bool& shouldExit, class PC88* pc88, class CoreRunner* coreRunner);
     void DismissConfirm();
     void DrawStatusBar(DiskManager* diskmgr);
+    void DrawOSDMessage();
     void DrawDriveStatus(DiskManager* diskmgr, int drive, float x, float y);
     std::string GetStatePath(DiskManager* diskmgr, int slot) const;
     std::string GetStateScreenshotPath(DiskManager* diskmgr, int slot) const;

--- a/src/raylib/disk_dialog.h
+++ b/src/raylib/disk_dialog.h
@@ -48,6 +48,11 @@ private:
     void DrawMainMenu(DiskManager* diskmgr, class PC88* pc88, bool& shouldExit, class CoreRunner* coreRunner);
     void DrawSettings(PC8801::Config& cfg, class PC88* pc88, class CoreRunner* coreRunner);
     void DrawDiskSelector(DiskManager* diskmgr);
+    void RefreshWriteProtectCache(DiskManager* diskmgr);
+    bool IsCurrentDiskWriteProtected(DiskManager* diskmgr, int drive);
+    // 書き込み禁止マークの鍵。GuiDrawIcon の pixelSize は整数倍しか取れないので、
+    // 一度 16px で焼いたテクスチャを任意サイズに縮小して描く。
+    void DrawKeyIcon(float x, float y, float size, Color color) const;
     void DrawRecentDiskDialog(DiskManager* diskmgr);
     void DrawStateDialog(DiskManager* diskmgr, class CoreRunner* coreRunner);
     void DrawConfirmDialog(bool& shouldExit, class PC88* pc88, class CoreRunner* coreRunner);
@@ -76,6 +81,17 @@ private:
     int currentStateSlot;
     Vector2 diskScrollOffset;
     Vector2 recentScrollOffset;
+
+    // ディスクセレクタ用の write-protect 状態キャッシュ。
+    // 判定はイメージのヘッダ読み込みを伴うので毎フレームは引かない。
+    std::vector<char> diskWriteProtect;
+    int wpCacheDrive;
+    std::string wpCachePath;
+
+    // ステータスバー用。挿入中のディスクの write-protect をドライブごとに保持する
+    bool statusWriteProtect[2];
+    std::string statusWpPath[2];
+    int statusWpIndex[2];
     
     // UI state
     int windowScale;
@@ -112,5 +128,7 @@ private:
     Texture2D statePreviewTexture;
     Font fontJp;
     Font fontEn;
+    RenderTexture2D keyIconTexture;
+    bool keyIconReady;
     bool resetPending;
 };


### PR DESCRIPTION
## Summary

ディスクマウント周辺と D&D のレビューで見つかった不具合をまとめて修正し、書き込み禁止ディスクの表示を追加します。

### マウント失敗時の破壊的挙動
- `DiskManager::Mount` は先頭で `Unmount` するため、ディスクイメージでないファイルをドロップすると**両ドライブが排出されていた**。`MountDisk` に quiet な `DiskImageHolder` による事前検証を追加し、開けない場合や挿入する枚が未対応メディア / m3u の実体欠落だった場合はドライブに触れず `false` を返す
- `MountDisk` を `bool` 化し、D&D の両経路 (raylib / Haiku) で失敗時に `resetondrop` のリセットを走らせない

### エラーがユーザーに伝わらない
- `StatusDisplay::GetCurrentMessage()` の呼び出し元が存在せず、コアが出すエラーが**すべて握り潰されていた**。OSD 表示を追加
- `StatusDisplay` に失効時刻を持たせ期限切れで自動的に消す。`duration <= 0` は「期限なし」として扱い `watchregister` / `showfdcstatus` を壊さない
- `diskmgr.cpp` の文字化けした Shift-JIS メッセージを英語化 (元の日本語は U+FFFD 化しており復元不能)

### 読み取り専用イメージへの書き込み消失
- `FileIO::Open` の読み込み専用フォールバックを `DiskImageHolder::Open` が検出できず、書き込み可能として扱っていた。`IsReadOnly()` の `playlist` 限定条件を外し、フォールバック検出を追加

### 書き戻し
- 誰も呼んでいなかった `DiskManager::Update()` をコアループから呼び、変更トラックを随時書き戻す
- `UpdateDrive()` の `holder`/`sizechanged` のロック外参照を修正
- `WriteTrackImage()` の失敗時に `modified` を落とさないようにする

### ステートセーブ
- `LoadState` が `ssh.disk[]` を無視しディスク番号を復元していなかった
- `datasize` と圧縮ペイロードのサイズを検証し、壊れたファイルで `bad_alloc` により落ちないようにする

### 書き込み禁止表示 (新機能)
- D88 ヘッダの write-protect フラグが立っているディスクに鍵アイコンを表示する。セレクタの各行の右端と、ステータスバーの FDD1/FDD2 のタイトル横
- ファイル自体の書き込み可否 (パーミッション等) は対象外
- 判定はヘッダ読み込みを伴うためキャッシュし、対象ディスクが変わったときだけ引き直す

### その他
- `DiskImageHolder` のコンストラクタが `diskname`/`ndisks`/`readonly` を未初期化のまま `Connect()` に渡していた
- `DrawStatusBar` が `d0 >= 0` の判定で `t0_raw` を逆参照していた
- ディスクタイトルの整形を `TrimDiskTitle()` に集約 (`find_last_not_of(" \0", n)` は NUL を落とせない)
- `DrawDiskSelector` が選択をループ内で処理し残りの行を別ドライブのタイトルで描いていた
- `FormatDisk` が `drive[dr]` ではなく `drive[0]` を更新していた (未使用コード)
- `NormalizeSelectedPath` が `file://` 以外でも percent-decode していた
- `UIManager` が `systemScroll` を未初期化のまま使っていた

## Test plan

`libm88core.a` にリンクした専用テストで確認しました。

- [x] 不正ファイルの quiet probe が無言で失敗し、OSD にメッセージが出ない
- [x] 書き込み不可 d88 → `IsReadOnly()=1` + "Read-only image" 表示 / 通常 d88 → `0`
- [x] m3u プレイリストの 2 ドライブ同時マウント (holder 共有、index 0/1)
- [x] m3u 内の読み取り専用エントリを `GetDisk()` 後に検出
- [x] OSD メッセージが期限切れで消える / `duration <= 0` は消えずに残る
- [x] ステート復元で 2 枚組イメージの `{D1=1, D2=0}` が正しく戻る (修正前は `D2=-1` になっていた)
- [x] 未対応 disktype の d88 / 実体が欠けた m3u / 2 枚目が未対応の m3u を `IsSupportedDisk()` が弾く
- [x] 事前検証に失敗したときドライブが元のまま (検証なしでは Drive 2 が排出されていた)
- [x] write-protect 判定: 保護なし=0 / D88 フラグあり=1 / ファイル権限のみ読取専用=0 / m3u はエントリごと
- [x] write-protect キャッシュが 60 フレームでヘッダ読み 1 回、ディスク変更時のみ引き直し
- [x] ビルド警告なし (残る警告は未変更の `fdc.cpp`/`crtc.cpp` の既存分)
- [x] アプリ起動確認

未確認: 鍵アイコンの実画面での見た目 (書き込み禁止ディスクをマウントした状態を自動で作れないため)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SyPbJCKMgm7PcsMyvyUMta