### PR TITLE
Fix ESC key leaking into emulated keyboard when closing menu

### DIFF
--- a/src/raylib/core_runner.cpp
+++ b/src/raylib/core_runner.cpp
@@ -305,13 +305,16 @@ bool CoreRunner::LoadState(const std::string& path, std::string* message) {
 }
 
 void CoreRunner::UpdateInput() {
+    if (!IsKeyDown(KEY_ESCAPE)) escOwnedByMenu = false;
     if (!uiManager.IsMenuOpen()) {
-        if (running) keyInput.Update();
+        if (running) keyInput.Update(escOwnedByMenu);
     }
 }
 
 void CoreRunner::UpdateUI(bool& shouldExit) {
+    bool menuWasOpen = uiManager.IsMenuOpen();
     uiManager.Update(shouldExit, this, this);
+    if (menuWasOpen && IsKeyDown(KEY_ESCAPE)) escOwnedByMenu = true;
 }
 
 void CoreRunner::DrawUI(bool& shouldExit) {

--- a/src/raylib/core_runner.h
+++ b/src/raylib/core_runner.h
@@ -63,4 +63,9 @@ private:
     std::atomic<bool> configResetPending;
     std::atomic<bool> resetPending;
     std::mutex stateMutex;
+
+    // ESC でメニュー/ダイアログを閉じた直後、同じキー押下が
+    // そのままエミュ側の ESC (STOP相当) にも入力されてしまうのを防ぐ。
+    // 物理キーが離されるまで、このキー押下はメニュー操作専用として扱う。
+    bool escOwnedByMenu = false;
 };

--- a/src/raylib/key_input.cpp
+++ b/src/raylib/key_input.cpp
@@ -37,7 +37,7 @@ bool KeyInput::Init(IOBus* bus) {
     return bus->Connect(this, connectors);
 }
 
-void KeyInput::Update() {
+void KeyInput::Update(bool suppressEscape) {
     memset(matrix, 0xff, sizeof(matrix));
 
     auto set_key = [&](int row, int bit, bool down) {
@@ -166,7 +166,7 @@ void KeyInput::Update() {
     set_key(9, 4, IsKeyDown(KEY_F4));
     set_key(9, 5, IsKeyDown(KEY_F5));
     set_key(9, 6, IsKeyDown(KEY_SPACE));
-    set_key(9, 7, IsKeyDown(KEY_ESCAPE));
+    set_key(9, 7, !suppressEscape && IsKeyDown(KEY_ESCAPE));
 
     // --- Row 10: TAB, DOWN, LEFT, HELP, COPY, Numpad-, Numpad/, CAPS ---
     set_key(0xa, 0, IsKeyDown(KEY_TAB));

--- a/src/raylib/key_input.h
+++ b/src/raylib/key_input.h
@@ -19,7 +19,7 @@ public:
     // IO Handlers
     uint IOCALL In(uint port);
 
-    void Update();
+    void Update(bool suppressEscape = false);
     bool Init(IOBus* bus);
 
 private:


### PR DESCRIPTION
## Summary
- メニューやダイアログを ESC で閉じると、同じフレーム内で `IsMenuOpen()` が false になり、押しっぱなしの物理 ESC キーがそのままエミュレートされた PC-88 キーボードの STOP キーとして送られてしまい、ゲームが意図せずポーズする不具合を修正
- `CoreRunner` に `escOwnedByMenu` フラグを追加し、メニューが開いていた時の ESC 押下は物理キーが離されるまでエミュ側への入力として扱わないようにした

## Test plan
- [x] ローカルでビルドが通ることを確認 (`cmake --build .`)
- [x] コード変更内容（ESC 抑制ロジック）をレビューし、メニュー表示中は従来通り `keyInput.Update()` がスキップされ、閉じた直後のフレームでも ESC が抑制されることを確認