### PR TITLE
fix(audio): stop unconditional audio device reinit on first reset

### DIFF
--- a/src/raylib/core_runner.cpp
+++ b/src/raylib/core_runner.cpp
@@ -74,6 +74,8 @@ bool CoreRunner::Init(Draw* draw) {
     if (!coreSound.Init(this, outrate, bufsize)) return false;
     coreSound.ApplyConfig(&Config::Get());
     sound.Init(outrate, bufsize);
+    lastAudioRate = outrate;
+    lastAudioBufMs = Config::Get().soundbuffer;
     sound.SetVolume(&Config::Get());
     sound.SetSource(coreSound.GetSoundSource());
 
@@ -120,6 +122,8 @@ void CoreRunner::RestartAudio() {
         GetOPN1()->Connect(&coreSound);
         GetOPN2()->Connect(&coreSound);
         GetBEEP()->Connect(&coreSound);
+        lastAudioRate = outrate;
+        lastAudioBufMs = cfg.soundbuffer;
     }
 }
 
@@ -371,18 +375,16 @@ void CoreRunner::Run() {
                 // Re-initialize audio if sampling rate or buffer size changed
                 uint32 currentRate = (uint32)Config::Get().sound;
                 int currentBufMs = (int)Config::Get().soundbuffer;
-                static uint32 lastRate = 0;
-                static int lastBufMs = 0;
-                
-                if (currentRate != lastRate || currentBufMs != lastBufMs) {
+
+                if (currentRate != lastAudioRate || currentBufMs != lastAudioBufMs) {
                     int samples = (int)(currentRate * currentBufMs / 1000);
                     if (samples < 1024) samples = 4096;
                     coreSound.Init(this, currentRate, samples);
                     sound.Cleanup();
                     sound.Init(currentRate, samples);
                     sound.Start();
-                    lastRate = currentRate;
-                    lastBufMs = currentBufMs;
+                    lastAudioRate = currentRate;
+                    lastAudioBufMs = currentBufMs;
                 }
 
                 Reset();

--- a/src/raylib/core_runner.h
+++ b/src/raylib/core_runner.h
@@ -64,6 +64,14 @@ private:
     std::atomic<bool> resetPending;
     std::mutex stateMutex;
 
+    // Run() 内でリセット時に音声デバイスの再初期化が必要かどうかを
+    // 判定するための直近の設定値。関数ローカルの static だと 0 から
+    // 始まってしまい、初回リセット時に必ず再初期化が走って
+    // (別スレッドからの InitAudioDevice/CloseAudioDevice 呼び出しにより)
+    // フリーズする不具合があったため、Init() で実際の初期値を設定する。
+    uint32 lastAudioRate = 0;
+    int lastAudioBufMs = 0;
+
     // ESC でメニュー/ダイアログを閉じた直後、同じキー押下が
     // そのままエミュ側の ESC (STOP相当) にも入力されてしまうのを防ぐ。
     // 物理キーが離されるまで、このキー押下はメニュー操作専用として扱う。


### PR DESCRIPTION
## Summary
- Mounting a disk and resetting could freeze the emulator: the reset handler in `CoreRunner::Run()` compared the audio rate/buffer-ms config against function-local `static` variables that always start at `0`, so the very first user-triggered reset looked like a settings change and reinitialized the audio device (`sound.Cleanup()` + `sound.Init()`) even though nothing had changed.
- That reinit calls `CloseAudioDevice()`/`InitAudioDevice()` from the emulation thread while audio playback is active, which froze the emulator.
- Moved the last-applied rate/buffer-ms tracking into `CoreRunner` member variables (`lastAudioRate`/`lastAudioBufMs`), seeded from the real config in `Init()` and `RestartAudio()`, so the reinit-on-reset path now only triggers when the audio settings actually change.

## Test plan
- [x] Built locally (`cmake --build`)
- [x] Reproduced the freeze with debug instrumentation (disk mount + reset via an automated test hook), confirmed the fix removes the freeze
- [ ] Manual verification on the reporter's environment (disk mount → reset no longer freezes)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01DxiHX8WPHyjQicTJT1oqzp