### PR TITLE
Fix crash on exit: release GPU resources before CloseWindow()

### DIFF
--- a/src/raylib/app.cpp
+++ b/src/raylib/app.cpp
@@ -377,6 +377,8 @@ int main() {
     }
 
     core.Stop();
+    // UIManager の GPU リソースは CloseWindow() より前に解放する必要がある。
+    core.GetUIManager()->Cleanup();
     draw.Cleanup();
     if (IsFontValid(fontJp)) UnloadFont(fontJp);
     if (IsFontValid(fontEn)) UnloadFont(fontEn);

--- a/src/raylib/audio_out.cpp
+++ b/src/raylib/audio_out.cpp
@@ -97,7 +97,7 @@ void RaylibSound::Cleanup() {
     }
 #else
     if (IsAudioStreamValid(stream)) { StopAudioStream(stream); UnloadAudioStream(stream); stream = {0}; }
-    CloseAudioDevice();
+    if (IsAudioDeviceReady()) CloseAudioDevice();
     if (s_current_sound == this) s_current_sound = nullptr;
 #endif
     updateBuffer.clear();

--- a/src/raylib/core_runner.cpp
+++ b/src/raylib/core_runner.cpp
@@ -337,7 +337,10 @@ void CoreRunner::Stop() {
         running = false;
         if (thread.joinable()) thread.join();
     }
-    StopAudio();
+    if (!audioStopped) {
+        StopAudio();
+        audioStopped = true;
+    }
 }
 
 void CoreRunner::Pause(bool p) { paused = p; }

--- a/src/raylib/core_runner.h
+++ b/src/raylib/core_runner.h
@@ -72,6 +72,10 @@ private:
     uint32 lastAudioRate = 0;
     int lastAudioBufMs = 0;
 
+    // Stop() は main() の終了処理と ~CoreRunner() の両方から呼ばれるため、
+    // StopAudio() の二重実行 (Device already closed 警告) を防ぐガード。
+    bool audioStopped = false;
+
     // ESC でメニュー/ダイアログを閉じた直後、同じキー押下が
     // そのままエミュ側の ESC (STOP相当) にも入力されてしまうのを防ぐ。
     // 物理キーが離されるまで、このキー押下はメニュー操作専用として扱う。

--- a/src/raylib/disk_dialog.cpp
+++ b/src/raylib/disk_dialog.cpp
@@ -334,11 +334,21 @@ UIManager::UIManager() :
 
 UIManager::~UIManager() {
     SaveRecent();
-    if (IsTextureValid(statePreviewTexture)) UnloadTexture(statePreviewTexture);
-    if (keyIconReady) UnloadRenderTexture(keyIconTexture);
+    Cleanup();
 #ifndef __HAIKU__
     NFD_Quit();
 #endif
+}
+
+void UIManager::Cleanup() {
+    if (IsTextureValid(statePreviewTexture)) {
+        UnloadTexture(statePreviewTexture);
+        statePreviewTexture = {0};
+    }
+    if (keyIconReady) {
+        UnloadRenderTexture(keyIconTexture);
+        keyIconReady = false;
+    }
 }
 
 void UIManager::DrawEnText(const char* text, int x, int y, Color color) const {

--- a/src/raylib/disk_dialog.h
+++ b/src/raylib/disk_dialog.h
@@ -12,6 +12,10 @@ public:
     ~UIManager();
 
     void Init();
+    // statePreviewTexture / keyIconTexture の GPU リソースを解放する。
+    // CloseWindow() より前に呼ぶこと。デストラクタでも呼ばれるが、その時点では
+    // CloseWindow() 済みで GL コンテキストが無く、Unload*() が未定義動作になる。
+    void Cleanup();
     void Update(bool& shouldExit, class PC88* pc88, class CoreRunner* coreRunner);
     void Draw(DiskManager* diskmgr, PC8801::Config& cfg, class PC88* pc88, class CoreRunner* coreRunner, bool& shouldExit);
     void OpenNativeDialog(DiskManager* diskmgr, int drive);


### PR DESCRIPTION
## Summary
- `UIManager`'s GPU resources (key icon `RenderTexture`, state preview `Texture`) were being released in its destructor, which runs after `CoreRunner`'s destructor — i.e. after `main()` already called `CloseWindow()`. Freeing GL resources with no GL context is undefined behavior, and crashed on exit on some GPU drivers (unnoticed on a software renderer, which is why it slipped through).
- Added `UIManager::Cleanup()` and call it explicitly right after `core.Stop()`, before `CloseWindow()`, so resources are freed while the context is still alive.
- Also quieted two harmless "Device could not be closed" warnings seen on exit, caused by `StopAudio()`/`RaylibSound::Cleanup()` running twice (once from `main()`'s shutdown, once from the destructor chain).

## Test plan
- [x] Built with `cmake --build build` (Debug) on Linux
- [x] Verified via temporary auto-close test hook + log inspection that `FBO`/`TEXTURE` unload log lines now appear *before* `Window closed successfully`, instead of after
- [x] Verified the "Device could not be closed" warnings no longer appear on exit
- [ ] Manual verification on Windows/macOS builds (not available in this environment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DR2LizRDUBhKRA44TA3KAa