### PR TITLE
fix(fdc): remove ReadDiagnostic OSD toast during gameplay

### DIFF
--- a/src/pc88/fdc.cpp
+++ b/src/pc88/fdc.cpp
@@ -1189,9 +1189,6 @@ void FDC::ReadDiagnostic()
 		uint dr = hdu & 3;
 		uint flags = ((hdu >> 2) & 1) | (command & 0x40) | (drive[dr].hd & 0x80);
 		uint size;
-		int tr = (drive[dr].cyrinder >> drive[dr].dd) * 2 + ((hdu>>2) & 1);
-		statusdisplay.Show(84, showstatus ? 1000 : 2000, 
-			"ReadDiagnostic (Dr%d Tr%d)", dr, tr);
 
 		result = diskmgr->GetFDU(dr)->MakeDiagData(flags, buffer, &size);
 		if (result)


### PR DESCRIPTION
## Summary
- FDC の Read Diagnostic コマンド実行時に表示していた `ReadDiagnostic (DrX TrY)` のOSDトーストを削除
- 他のFDCコマンド (Read/Write/ReadID/WriteID) は「Show FDC Status」設定が有効な時のみ表示されるが、ReadDiagnostic だけは無条件に表示されており、ソーサリアンのオープニングなどで通常プレイ中にゲーム画面へ被って表示されてしまう問題があった
- ディスクマウント失敗など、ユーザーに伝えるべき他のOSDメッセージ表示の仕組み自体には手を加えていない

## Test plan
- [x] `cmake --build .` でビルドが通ることを確認
- [x] `src/pc88/fdc.cpp` の変更差分が意図通り（ReadDiagnostic用の `statusdisplay.Show()` 呼び出しとトラック番号算出のみ削除）であることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rg91L7dcSjpYirGT9hWZXU